### PR TITLE
Make dependabot group minor version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      typescript:
+        applies-to: version-updates
+        patterns:
+          - "@types*"
+          - "typescript"
+          - "typescript-language-server"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Updates that maintain backwards compatibility should be grouped into a single PR now.