### PR TITLE
Add conferences ISAAC SODA STACS STOC (General theoretical CS)

### DIFF
--- a/data/papers.json
+++ b/data/papers.json
@@ -4798,5 +4798,2927 @@
     "title": "Optimal Offline ORAM with Perfect Security via Simple Oblivious Priority Queues.",
     "venue": "isaac 2024",
     "citation": "Thießen, Thore, and Jan Vahrenhold. Optimal Offline ORAM with Perfect Security via Simple Oblivious Priority Queues. With Julián Mestre and Anthony Wirth, Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2024, https://doi.org/10.4230/LIPICS.ISAAC.2024.55."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.32",
+    "title": "Approximately Counting Knapsack Solutions in Subquadratic Time.",
+    "venue": "soda 2025",
+    "citation": "Feng, Weiming, and Ce Jin. “Approximately Counting Knapsack Solutions in Subquadratic Time.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1094–135. Crossref, https://doi.org/10.1137/1.9781611978322.32."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.17",
+    "title": "Approximating Unrelated Machine Weighted Completion Time Using Iterative Rounding and Computer Assisted Proofs.",
+    "venue": "soda 2025",
+    "citation": "Li, Shi. “Approximating Unrelated Machine Weighted Completion Time Using Iterative Rounding and Computer Assisted Proofs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 553–71. Crossref, https://doi.org/10.1137/1.9781611978322.17."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.59",
+    "title": "Linear equations with monomial constraints and decision problems in abelian-by-cyclic groups.",
+    "venue": "soda 2025",
+    "citation": "Dong, Ruiwen. “Linear Equations with Monomial Constraints and Decision Problems in Abelian-by-Cyclic Groups.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1892–908. Crossref, https://doi.org/10.1137/1.9781611978322.59."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.125",
+    "title": "Losing Treewidth In The Presence Of Weights.",
+    "venue": "soda 2025",
+    "citation": "Włodarczyk, Michal. “Losing Treewidth In The Presence Of Weights.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3743–61. Crossref, https://doi.org/10.1137/1.9781611978322.125."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.54",
+    "title": "A Multi-Dimensional Online Contention Resolution Scheme for Revenue Maximization.",
+    "venue": "soda 2025",
+    "citation": "Chawla, Shuchi, et al. “A Multi-Dimensional Online Contention Resolution Scheme for Revenue Maximization.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1720–57. Crossref, https://doi.org/10.1137/1.9781611978322.54."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.11",
+    "title": "Relative-error monotonicity testing.",
+    "venue": "soda 2025",
+    "citation": "Chen, Xi, et al. “Relative-Error Monotonicity Testing.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 373–402. Crossref, https://doi.org/10.1137/1.9781611978322.11."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.13",
+    "title": "Lower Bounds for Convexity Testing.",
+    "venue": "soda 2025",
+    "citation": "Chen, Xi, et al. “Lower Bounds for Convexity Testing.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 446–88. Crossref, https://doi.org/10.1137/1.9781611978322.13."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.34",
+    "title": "Approximating Traveling Salesman Problems Using a Bridge Lemma.",
+    "venue": "soda 2025",
+    "citation": "Böhm, Martin, et al. “Approximating Traveling Salesman Problems Using a Bridge Lemma.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1166–77. Crossref, https://doi.org/10.1137/1.9781611978322.34."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.84",
+    "title": "Tolls for Dynamic Equilibrium Flows.",
+    "venue": "soda 2025",
+    "citation": "Graf, Lukas, et al. “Tolls for Dynamic Equilibrium Flows.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2560–606. Crossref, https://doi.org/10.1137/1.9781611978322.84."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.65",
+    "title": "Quasi-Monte Carlo Beyond Hardy-Krause.",
+    "venue": "soda 2025",
+    "citation": "Bansal, Nikhil, and Haotian Jiang. “Quasi-Monte Carlo Beyond Hardy-Krause.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2051–75. Crossref, https://doi.org/10.1137/1.9781611978322.65."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.10",
+    "title": "Breaking the Two Approximation Barrier for Various Consensus Clustering Problems.",
+    "venue": "soda 2025",
+    "citation": "Das, Debarati, and Amit Kumar. “Breaking the Two Approximation Barrier for Various Consensus Clustering Problems.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 323–72. Crossref, https://doi.org/10.1137/1.9781611978322.10."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.123",
+    "title": "Maximum Span Hypothesis: A Potentially Weaker Assumption than Gap-ETH for Parameterized Complexity.",
+    "venue": "soda 2025",
+    "citation": "C. S., Karthik, and Subhash Khot. “Maximum Span Hypothesis: A Potentially Weaker Assumption than Gap-ETH for Parameterized Complexity.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3696–727. Crossref, https://doi.org/10.1137/1.9781611978322.123."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.6",
+    "title": "Beyond 2-Approximation for k-Center in Graphs.",
+    "venue": "soda 2025",
+    "citation": "Jin, Ce, et al. “Beyond 2-Approximation for k-Center in Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 175–211. Crossref, https://doi.org/10.1137/1.9781611978322.6."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.46",
+    "title": "Unbreakable Decomposition in Close-to-Linear Time.",
+    "venue": "soda 2025",
+    "citation": "Anand, Aditya, et al. “Unbreakable Decomposition in Close-to-Linear Time.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1464–93. Crossref, https://doi.org/10.1137/1.9781611978322.46."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.132",
+    "title": "The Power of Proportional Fairness for Non-Clairvoyant Scheduling under Polyhedral Constraints.",
+    "venue": "soda 2025",
+    "citation": "Jäger, Sven, et al. “The Power of Proportional Fairness for Non-Clairvoyant Scheduling under Polyhedral Constraints.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3901–30. Crossref, https://doi.org/10.1137/1.9781611978322.132."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.35",
+    "title": "Min-CSPs on Complete Instances.",
+    "venue": "soda 2025",
+    "citation": "Anand, Aditya, et al. “Min-CSPs on Complete Instances.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1178–201. Crossref, https://doi.org/10.1137/1.9781611978322.35."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.33",
+    "title": "Balancing Notions of Equity: Trade-offs Between Fair Portfolio Sizes and Achievable Guarantees.",
+    "venue": "soda 2025",
+    "citation": "Gupta, Swati, et al. “Balancing Notions of Equity: Trade-Offs Between Fair Portfolio Sizes and Achievable Guarantees.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1136–65. Crossref, https://doi.org/10.1137/1.9781611978322.33."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.137",
+    "title": "Top-k Document Retrieval in Compressed Space.",
+    "venue": "soda 2025",
+    "citation": "Navarro, Gonzalo, and Yakov Nekrich. “Top-k Document Retrieval in Compressed Space.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4009–30. Crossref, https://doi.org/10.1137/1.9781611978322.137."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.4",
+    "title": "Deterministic Edge Connectivity and Max Flow using Subquadratic Cut Queries.",
+    "venue": "soda 2025",
+    "citation": "Anand, Aditya, et al. “Deterministic Edge Connectivity and Max Flow Using Subquadratic Cut Queries.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 124–42. Crossref, https://doi.org/10.1137/1.9781611978322.4."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.143",
+    "title": "On the Locality of Hall&apos;s Theorem.",
+    "venue": "soda 2025",
+    "citation": "Brandt, Sebastian, et al. “On the Locality of Hall’s Theorem.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4198–226. Crossref, https://doi.org/10.1137/1.9781611978322.143."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.99",
+    "title": "Entropy Regularization and Faster Decremental Matching in General Graphs.",
+    "venue": "soda 2025",
+    "citation": "Chen, Jiale, et al. “Entropy Regularization and Faster Decremental Matching in General Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3069–115. Crossref, https://doi.org/10.1137/1.9781611978322.99."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.68",
+    "title": "Congestion-Approximators from the Bottom Up.",
+    "venue": "soda 2025",
+    "citation": "Li, Jason, et al. “Congestion-Approximators from the Bottom Up.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2111–31. Crossref, https://doi.org/10.1137/1.9781611978322.68."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.114",
+    "title": "Understanding Memory-Regret Trade-Off for Streaming Stochastic Multi-Armed Bandits.",
+    "venue": "soda 2025",
+    "citation": "He, Yuchen, et al. “Understanding Memory-Regret Trade-Off for Streaming Stochastic Multi-Armed Bandits.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3450–85. Crossref, https://doi.org/10.1137/1.9781611978322.114."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.81",
+    "title": "Path and Intersections: Characterization of Quasi-metrics in Directed Okamura-Seymour Instances.",
+    "venue": "soda 2025",
+    "citation": "Chen, Yu, and Zihan Tan. “Path and Intersections: Characterization of Quasi-Metrics in Directed Okamura-Seymour Instances.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2467–90. Crossref, https://doi.org/10.1137/1.9781611978322.81."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.153",
+    "title": "Recognizing Sumsets is NP-Complete.",
+    "venue": "soda 2025",
+    "citation": "Abboud, Amir, et al. “Recognizing Sumsets Is NP-Complete.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4484–506. Crossref, https://doi.org/10.1137/1.9781611978322.153."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.172",
+    "title": "Differentiable Approximations for Distance Queries.",
+    "venue": "soda 2025",
+    "citation": "Abdelkader, Ahmed, and David M. Mount. “Differentiable Approximations for Distance Queries.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5065–99. Crossref, https://doi.org/10.1137/1.9781611978322.172."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.118",
+    "title": "Partitioning a Polygon Into Small Pieces.",
+    "venue": "soda 2025",
+    "citation": "Abrahamsen, Mikkel, and Nichlas Langhoff Rasmussen. “Partitioning a Polygon Into Small Pieces.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3562–89. Crossref, https://doi.org/10.1137/1.9781611978322.118."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.136",
+    "title": "A Cell Probe Lower Bound for the Predecessor Search Problem in PRAM.",
+    "venue": "soda 2025",
+    "citation": "Afshani, Peyman, and Nodari Sitchinava. “A Cell Probe Lower Bound for the Predecessor Search Problem in PRAM.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3998–4008. Crossref, https://doi.org/10.1137/1.9781611978322.136."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.92",
+    "title": "Private Mean Estimation with Person-Level Differential Privacy.",
+    "venue": "soda 2025",
+    "citation": "Agarwal, Sushant, et al. “Private Mean Estimation with Person-Level Differential Privacy.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2819–80. Crossref, https://doi.org/10.1137/1.9781611978322.92."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.163",
+    "title": "Efficient Approximation Algorithm for Computing Wasserstein Barycenter under Euclidean Metric.",
+    "venue": "soda 2025",
+    "citation": "Agarwal, Pankaj K., et al. “Efficient Approximation Algorithm for Computing Wasserstein Barycenter under Euclidean Metric.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4809–26. Crossref, https://doi.org/10.1137/1.9781611978322.163."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.109",
+    "title": "A coarse Erdős-Pósa theorem.",
+    "venue": "soda 2025",
+    "citation": "Ahn, Jungho, et al. “A Coarse Erdős-Pósa Theorem.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3363–81. Crossref, https://doi.org/10.1137/1.9781611978322.109."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.82",
+    "title": "On the Uniqueness of Bayesian Coarse Correlated Equilibria in Standard First-Price and All-Pay Auctions.",
+    "venue": "soda 2025",
+    "citation": "Ahunbay, Mete Şeref, and Martin Bichler. “On the Uniqueness of Bayesian Coarse Correlated Equilibria in Standard First-Price and All-Pay Auctions.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2491–537. Crossref, https://doi.org/10.1137/1.9781611978322.82."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.171",
+    "title": "Facet-Hamiltonicity.",
+    "venue": "soda 2025",
+    "citation": "Akitaya, Hugo, et al. “Facet-Hamiltonicity.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5051–64. Crossref, https://doi.org/10.1137/1.9781611978322.171."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.141",
+    "title": "Sublinear-Round Broadcast without Trusted Setup.",
+    "venue": "soda 2025",
+    "citation": "Alexandru, Andreea B., et al. “Sublinear-Round Broadcast without Trusted Setup.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4132–71. Crossref, https://doi.org/10.1137/1.9781611978322.141."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.63",
+    "title": "More Asymmetry Yields Faster Matrix Multiplication.",
+    "venue": "soda 2025",
+    "citation": "Alman, Josh, et al. “More Asymmetry Yields Faster Matrix Multiplication.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2005–39. Crossref, https://doi.org/10.1137/1.9781611978322.63."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.61",
+    "title": "Improving the Leading Constant of Matrix Multiplication.",
+    "venue": "soda 2025",
+    "citation": "Alman, Josh, and Hantao Yu. “Improving the Leading Constant of Matrix Multiplication.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1933–71. Crossref, https://doi.org/10.1137/1.9781611978322.61."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.187",
+    "title": "Low Degree Local Correction Over the Boolean Cube.",
+    "venue": "soda 2025",
+    "citation": "Amireddy, Prashanth, et al. “Low Degree Local Correction Over the Boolean Cube.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5504–11. Crossref, https://doi.org/10.1137/1.9781611978322.187."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.76",
+    "title": "Integer programs with nearly totally unimodular matrices: the cographic case.",
+    "venue": "soda 2025",
+    "citation": "Aprile, Manuel, et al. “Integer Programs with Nearly Totally Unimodular Matrices: The Cographic Case.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2301–12. Crossref, https://doi.org/10.1137/1.9781611978322.76."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.41",
+    "title": "An Elementary Predictor Obtaining Distance to Calibration.",
+    "venue": "soda 2025",
+    "citation": "Arunachaleswaran, Eshwar Ram, et al. “An Elementary Predictor Obtaining Distance to Calibration.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1366–70. Crossref, https://doi.org/10.1137/1.9781611978322.41."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.180",
+    "title": "Faster Approximation Algorithms for Restricted Shortest Paths in Directed Graphs.",
+    "venue": "soda 2025",
+    "citation": "Ashvinkumar, Vikrant, et al. “Faster Approximation Algorithms for Restricted Shortest Paths in Directed Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5263–77. Crossref, https://doi.org/10.1137/1.9781611978322.180."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.165",
+    "title": "Faster Vizing and Near-Vizing Edge Coloring Algorithms.",
+    "venue": "soda 2025",
+    "citation": "Assadi, Sepehr. “Faster Vizing and Near-Vizing Edge Coloring Algorithms.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4861–98. Crossref, https://doi.org/10.1137/1.9781611978322.165."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.25",
+    "title": "Settling the Pass Complexity of Approximate Matchings in Dynamic Graph Streams.",
+    "venue": "soda 2025",
+    "citation": "Assadi, Sepehr, et al. “Settling the Pass Complexity of Approximate Matchings in Dynamic Graph Streams.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 864–904. Crossref, https://doi.org/10.1137/1.9781611978322.25."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.113",
+    "title": "Streaming and Communication Complexity of Load-Balancing via Matching Contractors.",
+    "venue": "soda 2025",
+    "citation": "Assadi, Sepehr, et al. “Streaming and Communication Complexity of Load-Balancing via Matching Contractors.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3423–49. Crossref, https://doi.org/10.1137/1.9781611978322.113."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.96",
+    "title": "Improved Bounds for Fully Dynamic Matching via Ordered Ruzsa-Szemerédi Graphs.",
+    "venue": "soda 2025",
+    "citation": "Assadi, Sepehr, et al. “Improved Bounds for Fully Dynamic Matching via Ordered Ruzsa-Szemerédi Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2971–90. Crossref, https://doi.org/10.1137/1.9781611978322.96."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.142",
+    "title": "Fully-Distributed Byzantine Agreement in Sparse Networks.",
+    "venue": "soda 2025",
+    "citation": "Augustine, John, et al. “Fully-Distributed Byzantine Agreement in Sparse Networks.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4172–97. Crossref, https://doi.org/10.1137/1.9781611978322.142."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.5",
+    "title": "Massively Parallel Minimum Spanning Tree in General Metric Spaces.",
+    "venue": "soda 2025",
+    "citation": "Azarmehr, Amir, et al. “Massively Parallel Minimum Spanning Tree in General Metric Spaces.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 143–74. Crossref, https://doi.org/10.1137/1.9781611978322.5."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.73",
+    "title": "Forall-exist statements in pseudopolynomial time.",
+    "venue": "soda 2025",
+    "citation": "Bach, Eleonore, et al. “Forall-Exist Statements in Pseudopolynomial Time.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2225–33. Crossref, https://doi.org/10.1137/1.9781611978322.73."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.131",
+    "title": "Unweighted Layered Graph Traversal: Passing a Crown via Entropy Maximization.",
+    "venue": "soda 2025",
+    "citation": "Bai, Xingjian, et al. “Unweighted Layered Graph Traversal: Passing a Crown via Entropy Maximization.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3884–900. Crossref, https://doi.org/10.1137/1.9781611978322.131."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.18",
+    "title": "Lift-and-Project Integrality Gaps for Santa Claus.",
+    "venue": "soda 2025",
+    "citation": "Bamas, Etienne. “Lift-and-Project Integrality Gaps for Santa Claus.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 572–615. Crossref, https://doi.org/10.1137/1.9781611978322.18."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.19",
+    "title": "The Submodular Santa Claus Problem.",
+    "venue": "soda 2025",
+    "citation": "Bamas, Étienne, et al. “The Submodular Santa Claus Problem.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 616–40. Crossref, https://doi.org/10.1137/1.9781611978322.19."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.78",
+    "title": "PTASes for Euclidean TSP with Unit Disk and Unit Square Neighborhoods.",
+    "venue": "soda 2025",
+    "citation": "Bandyapadhyay, Sayan, et al. “PTASes for Euclidean TSP with Unit Disk and Unit Square Neighborhoods.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2326–56. Crossref, https://doi.org/10.1137/1.9781611978322.78."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.57",
+    "title": "Majorized Bayesian Persuasion and Fair Selection.",
+    "venue": "soda 2025",
+    "citation": "Banerjee, Siddhartha, et al. “Majorized Bayesian Persuasion and Fair Selection.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1837–56. Crossref, https://doi.org/10.1137/1.9781611978322.57."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.12",
+    "title": "Nearly Tight Bounds on Testing of Metric Properties.",
+    "venue": "soda 2025",
+    "citation": "Bao, Yiqiao, et al. “Nearly Tight Bounds on Testing of Metric Properties.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 403–45. Crossref, https://doi.org/10.1137/1.9781611978322.12."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.80",
+    "title": "Strict Self-Assembly of Discrete Self-Similar Fractals in the abstract Tile Assembly Model.",
+    "venue": "soda 2025",
+    "citation": "Becker, Florent, et al. “Strict Self-Assembly of Discrete Self-Similar Fractals in the Abstract Tile Assembly Model.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2387–466. Crossref, https://doi.org/10.1137/1.9781611978322.80."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.169",
+    "title": "Fully Dynamic (Δ + 1)-Coloring Against Adaptive Adversaries.",
+    "venue": "soda 2025",
+    "citation": "Behnezhad, Soheil, et al. “Fully Dynamic (Δ + 1)-Coloring Against Adaptive Adversaries.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4983–5026. Crossref, https://doi.org/10.1137/1.9781611978322.169."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.45",
+    "title": "Packing Short Cycles.",
+    "venue": "soda 2025",
+    "citation": "Bentert, Matthias, et al. “Packing Short Cycles.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1425–63. Crossref, https://doi.org/10.1137/1.9781611978322.45."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.52",
+    "title": "Quasilinear-time eccentricities computation, and more, on median graphs.",
+    "venue": "soda 2025",
+    "citation": "Bergé, Pierre, et al. “Quasilinear-Time Eccentricities Computation, and More, on Median Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1679–704. Crossref, https://doi.org/10.1137/1.9781611978322.52."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.97",
+    "title": "Matching Composition and Efficient Weight Reduction in Dynamic Matching.",
+    "venue": "soda 2025",
+    "citation": "Bernstein, Aaron, et al. “Matching Composition and Efficient Weight Reduction in Dynamic Matching.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2991–3028. Crossref, https://doi.org/10.1137/1.9781611978322.97."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.170",
+    "title": "Relating Interleaving and Fréchet Distances via Ordered Merge Trees.",
+    "venue": "soda 2025",
+    "citation": "Beurskens, Thijs, et al. “Relating Interleaving and Fréchet Distances via Ordered Merge Trees.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5027–50. Crossref, https://doi.org/10.1137/1.9781611978322.170."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.88",
+    "title": "Improved Spectral Density Estimation via Explicit and Implicit Deflation.",
+    "venue": "soda 2025",
+    "citation": "Bhattacharjee, Rajarshi, et al. “Improved Spectral Density Estimation via Explicit and Implicit Deflation.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2693–754. Crossref, https://doi.org/10.1137/1.9781611978322.88."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.167",
+    "title": "Even Faster (Δ + 1)-Edge Coloring via Shorter Multi-Step Vizing Chains.",
+    "venue": "soda 2025",
+    "citation": "Bhattacharya, Sayan, et al. “Even Faster (Δ + 1)-Edge Coloring via Shorter Multi-Step Vizing Chains.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4914–47. Crossref, https://doi.org/10.1137/1.9781611978322.167."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.79",
+    "title": "Fast Static and Dynamic Approximation Algorithms for Geometric Optimization Problems: Piercing, Independent Set, Vertex Cover, and Matching.",
+    "venue": "soda 2025",
+    "citation": "Bhore, Sujoy, and Timothy M. Chan. “Fast Static and Dynamic Approximation Algorithms for Geometric Optimization Problems: Piercing, Independent Set, Vertex Cover, and Matching.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2357–86. Crossref, https://doi.org/10.1137/1.9781611978322.79."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.145",
+    "title": "Spanners in Planar Domains via Steiner Spanners and non-Steiner Tree Covers.",
+    "venue": "soda 2025",
+    "citation": "Bhore, Sujoy, et al. “Spanners in Planar Domains via Steiner Spanners and Non-Steiner Tree Covers.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4292–326. Crossref, https://doi.org/10.1137/1.9781611978322.145."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.77",
+    "title": "Flipping Non-Crossing Spanning Trees.",
+    "venue": "soda 2025",
+    "citation": "Bjerkevik, Håvard Bakke, et al. “Flipping Non-Crossing Spanning Trees.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2313–25. Crossref, https://doi.org/10.1137/1.9781611978322.77."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.91",
+    "title": "Fast Deterministic Chromatic Number under the Asymptotic Rank Conjecture.",
+    "venue": "soda 2025",
+    "citation": "Björklund, Andreas, et al. “Fast Deterministic Chromatic Number under the Asymptotic Rank Conjecture.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2804–18. Crossref, https://doi.org/10.1137/1.9781611978322.91."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.185",
+    "title": "Mean-field Potts and random-cluster dynamics from high-entropy initializations.",
+    "venue": "soda 2025",
+    "citation": "Blanca, Antonio, et al. “Mean-Field Potts and Random-Cluster Dynamics from High-Entropy Initializations.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5434–67. Crossref, https://doi.org/10.1137/1.9781611978322.185."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.49",
+    "title": "Deterministic Online Bipartite Edge Coloring.",
+    "venue": "soda 2025",
+    "citation": "Blikstad, Joakim, et al. “Deterministic Online Bipartite Edge Coloring.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1593–606. Crossref, https://doi.org/10.1137/1.9781611978322.49."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.127",
+    "title": "Competitive strategies to use &quot;warm start&quot; algorithms with predictions.",
+    "venue": "soda 2025",
+    "citation": "Blum, Avrim, and Vaidehi Srinivas. “Competitive Strategies to Use ‘Warm Start’ Algorithms with Predictions.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3775–801. Crossref, https://doi.org/10.1137/1.9781611978322.127."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.146",
+    "title": "A Lower Bound for Light Spanners in General Graphs.",
+    "venue": "soda 2025",
+    "citation": "Bodwin, Greg, and Jeremy Flics. “A Lower Bound for Light Spanners in General Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4327–37. Crossref, https://doi.org/10.1137/1.9781611978322.146."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.149",
+    "title": "Improved Online Reachability Preservers.",
+    "venue": "soda 2025",
+    "citation": "Bodwin, Greg, and Tuong Le. “Improved Online Reachability Preservers.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4375–404. Crossref, https://doi.org/10.1137/1.9781611978322.149."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.179",
+    "title": "Improved Shortest Path Restoration Lemmas for Multiple Edge Failures: Trade-offs Between Fault-tolerance and Subpaths.",
+    "venue": "soda 2025",
+    "citation": "Bodwin, Greg, and Lily Wang. “Improved Shortest Path Restoration Lemmas for Multiple Edge Failures: Trade-Offs Between Fault-Tolerance and Subpaths.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5245–62. Crossref, https://doi.org/10.1137/1.9781611978322.179."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.129",
+    "title": "Stronger adversaries grow cheaper forests: online node-weighted Steiner problems.",
+    "venue": "soda 2025",
+    "citation": "Borst, Sander, et al. “Stronger Adversaries Grow Cheaper Forests: Online Node-Weighted Steiner Problems.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3842–64. Crossref, https://doi.org/10.1137/1.9781611978322.129."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.101",
+    "title": "Bounding ε-scatter dimension via metric sparsity.",
+    "venue": "soda 2025",
+    "citation": "Bourneuf, Romain, and Marcin Pilipczuk. “Bounding ε-Scatter Dimension via Metric Sparsity.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3155–71. Crossref, https://doi.org/10.1137/1.9781611978322.101."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.98",
+    "title": "New Philosopher Inequalities for Online Bayesian Matching, via Pivotal Sampling.",
+    "venue": "soda 2025",
+    "citation": "Braverman, Mark, et al. “New Philosopher Inequalities for Online Bayesian Matching, via Pivotal Sampling.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3029–68. Crossref, https://doi.org/10.1137/1.9781611978322.98."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.157",
+    "title": "Beating Bellman&apos;s Algorithm for Subset Sum.",
+    "venue": "soda 2025",
+    "citation": "Bringmann, Karl, et al. “Beating Bellman’s Algorithm for Subset Sum.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4596–612. Crossref, https://doi.org/10.1137/1.9781611978322.157."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.24",
+    "title": "Nearly Optimal Dynamic Set Cover: Breaking the Quadratic-in-f Time Barrier.",
+    "venue": "soda 2025",
+    "citation": "Bukov, Anton, et al. “Nearly Optimal Dynamic Set Cover: Breaking the Quadratic-in-f Time Barrier.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 824–63. Crossref, https://doi.org/10.1137/1.9781611978322.24."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.184",
+    "title": "Optimal Mixing for Randomly Sampling Edge Colorings on Trees Down to the Max Degree.",
+    "venue": "soda 2025",
+    "citation": "Carlson, Charlie, et al. “Optimal Mixing for Randomly Sampling Edge Colorings on Trees Down to the Max Degree.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5418–33. Crossref, https://doi.org/10.1137/1.9781611978322.184."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.71",
+    "title": "Flip Dynamics for Sampling Colorings: Improving (11/6 - ε) Using A Simple Metric.",
+    "venue": "soda 2025",
+    "citation": "Carlson, Charlie, and Eric Vigoda. “Flip Dynamics for Sampling Colorings: Improving (11/6 — ε) Using A Simple Metric.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2194–212. Crossref, https://doi.org/10.1137/1.9781611978322.71."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.55",
+    "title": "Hiring for An Uncertain Task: Joint Design of Information and Contracts.",
+    "venue": "soda 2025",
+    "citation": "Castiglioni, Matteo, and Junjie Chen. “Hiring for An Uncertain Task: Joint Design of Information and Contracts.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1758–94. Crossref, https://doi.org/10.1137/1.9781611978322.55."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.56",
+    "title": "A Reduction from Multi-Parameter to Single-Parameter Bayesian Contract Design.",
+    "venue": "soda 2025",
+    "citation": "Castiglioni, Matteo, et al. “A Reduction from Multi-Parameter to Single-Parameter Bayesian Contract Design.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1795–836. Crossref, https://doi.org/10.1137/1.9781611978322.56."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.39",
+    "title": "New Combinatorial Insights for Monotone Apportionment.",
+    "venue": "soda 2025",
+    "citation": "Cembrano, Javier, et al. “New Combinatorial Insights for Monotone Apportionment.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1308–28. Crossref, https://doi.org/10.1137/1.9781611978322.39."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.3",
+    "title": "Embedding Planar Graphs into Graphs of Treewidth O (log3 n ).",
+    "venue": "soda 2025",
+    "citation": "Chang, Hsien-Chih, et al. “Embedding Planar Graphs into Graphs of Treewidth O (Log3 n ).” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 88–123. Crossref, https://doi.org/10.1137/1.9781611978322.3."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.102",
+    "title": "The Johnson-Lindenstrauss Lemma for Clustering and Subspace Approximation: From Coresets to Dimension Reduction.",
+    "venue": "soda 2025",
+    "citation": "Charika, Moses, and Erik Waingarten. “The Johnson-Lindenstrauss Lemma for Clustering and Subspace Approximation: From Coresets to Dimension Reduction.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3172–209. Crossref, https://doi.org/10.1137/1.9781611978322.102."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.103",
+    "title": "Embedding Probability Distributions into Low Dimensional ℓ1: Tree Ising Models via Truncated Metrics.",
+    "venue": "soda 2025",
+    "citation": "Charikar, Moses, et al. “Embedding Probability Distributions into Low Dimensional ℓ1: Tree Ising Models via Truncated Metrics.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3210–66. Crossref, https://doi.org/10.1137/1.9781611978322.103."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.177",
+    "title": "New Approximation Algorithms and Reductions for n-Pairs Shortest Paths and All-Nodes Shortest Cycles.",
+    "venue": "soda 2025",
+    "citation": "Chechik, Shiri, et al. “New Approximation Algorithms and Reductions for n-Pairs Shortest Paths and All-Nodes Shortest Cycles.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5207–38. Crossref, https://doi.org/10.1137/1.9781611978322.177."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.67",
+    "title": "A Polylogarithmic Approximation for Directed Steiner Forest in Planar Digraphs.",
+    "venue": "soda 2025",
+    "citation": "Chekuri, Chandra, and Rhea Jain. “A Polylogarithmic Approximation for Directed Steiner Forest in Planar Digraphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2095–110. Crossref, https://doi.org/10.1137/1.9781611978322.67."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.42",
+    "title": "Prophet Secretary and Matching: the Significance of the Largest Item.",
+    "venue": "soda 2025",
+    "citation": "Chen, Ziyun, et al. “Prophet Secretary and Matching: The Significance of the Largest Item.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1371–401. Crossref, https://doi.org/10.1137/1.9781611978322.42."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.108",
+    "title": "Unique-neighbor Expanders with Better Expansion for Polynomial-sized Sets.",
+    "venue": "soda 2025",
+    "citation": "Sets, Polynomial-sized, and Yeyuan Chen. “Unique-Neighbor Expanders with Better Expansion For.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3335–62. Crossref, https://doi.org/10.1137/1.9781611978322.108."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.29",
+    "title": "A Quantum Speed-Up for Approximating the Top Eigenvectors of a Matrix.",
+    "venue": "soda 2025",
+    "citation": "Chen, Yanlin, et al. “A Quantum Speed-Up for Approximating the Top Eigenvectors of a Matrix.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 994–1036. Crossref, https://doi.org/10.1137/1.9781611978322.29."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.128",
+    "title": "Online Scheduling via Gradient Descent for Weighted Flow Time Minimization.",
+    "venue": "soda 2025",
+    "citation": "Chen, Qingyun, et al. “Online Scheduling via Gradient Descent for Weighted Flow Time Minimization.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3802–41. Crossref, https://doi.org/10.1137/1.9781611978322.128."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.87",
+    "title": "Near-optimal hierarchical matrix approximation from matrix-vector products.",
+    "venue": "soda 2025",
+    "citation": "Chen, Tyler, et al. “Near-Optimal Hierarchical Matrix Approximation from Matrix-Vector Products.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2656–92. Crossref, https://doi.org/10.1137/1.9781611978322.87."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.53",
+    "title": "Parallel and Distributed Expander Decomposition: Simple, Fast, and Near-Optimal.",
+    "venue": "soda 2025",
+    "citation": "Chen, Daoyuan, et al. “Parallel and Distributed Expander Decomposition: Simple, Fast, and Near-Optimal.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1705–19. Crossref, https://doi.org/10.1137/1.9781611978322.53."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.159",
+    "title": "Exact Thresholds for Noisy Non-Adaptive Group Testing.",
+    "venue": "soda 2025",
+    "citation": "Chen, Junren, and Jonathan Scarlett. “Exact Thresholds for Noisy Non-Adaptive Group Testing.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4644–706. Crossref, https://doi.org/10.1137/1.9781611978322.159."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.105",
+    "title": "Outlier-robust Mean Estimation near the Breakdown Point via Sum-of-Squares.",
+    "venue": "soda 2025",
+    "citation": "Chen, Hongjie, et al. “Outlier-Robust Mean Estimation near the Breakdown Point via Sum-of-Squares.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3277–309. Crossref, https://doi.org/10.1137/1.9781611978322.105."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.183",
+    "title": "Spectral Independence Beyond Total Influence on Trees and Related Graphs.",
+    "venue": "soda 2025",
+    "citation": "Chen, Xiaoyu, et al. “Spectral Independence Beyond Total Influence on Trees and Related Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5388–417. Crossref, https://doi.org/10.1137/1.9781611978322.183."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.173",
+    "title": "Fréchet Distance in Subquadratic Time.",
+    "venue": "soda 2025",
+    "citation": "Cheng, Siu-Wing, and Haoqiang Huang. “Fréchet Distance in Subquadratic Time.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5100–13. Crossref, https://doi.org/10.1137/1.9781611978322.173."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.151",
+    "title": "Tree Independence Number IV. Even-hole-free graphs.",
+    "venue": "soda 2025",
+    "citation": "Chudnovsky, Maria, et al. “Tree Independence Number IV. Even-Hole-Free Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4444–61. Crossref, https://doi.org/10.1137/1.9781611978322.151."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.23",
+    "title": "Fully Dynamic Algorithms for Graph Spanners via Low-Diameter Router Decomposition.",
+    "venue": "soda 2025",
+    "citation": "Chuzhoy, Julia, and Merav Parter. “Fully Dynamic Algorithms for Graph Spanners via Low-Diameter Router Decomposition.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 785–823. Crossref, https://doi.org/10.1137/1.9781611978322.23."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.144",
+    "title": "Partial Synchrony for Free: New Upper Bounds for Byzantine Agreement.",
+    "venue": "soda 2025",
+    "citation": "Civit, Pierre, et al. “Partial Synchrony for Free: New Upper Bounds for Byzantine Agreement.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4227–91. Crossref, https://doi.org/10.1137/1.9781611978322.144."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.162",
+    "title": "A Tight VC-Dimension Analysis of Clustering Coresets with Applications.",
+    "venue": "soda 2025",
+    "citation": "Cohen-Addad, Vincent, et al. “A Tight VC-Dimension Analysis of Clustering Coresets with Applications.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4783–808. Crossref, https://doi.org/10.1137/1.9781611978322.162."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.140",
+    "title": "Asynchronous 3-Majority Dynamics with Many Opinions.",
+    "venue": "soda 2025",
+    "citation": "Cooper, Colin, et al. “Asynchronous 3-Majority Dynamics with Many Opinions.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4095–131. Crossref, https://doi.org/10.1137/1.9781611978322.140."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.122",
+    "title": "Counting Small Induced Subgraphs: Hardness via Fourier Analysis.",
+    "venue": "soda 2025",
+    "citation": "Curticapean, Radu, and Daniel Neuen. “Counting Small Induced Subgraphs: Hardness via Fourier Analysis.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3677–95. Crossref, https://doi.org/10.1137/1.9781611978322.122."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.158",
+    "title": "Average-Case Hardness of Parity Problems: Orthogonal Vectors, k-SUM and More.",
+    "venue": "soda 2025",
+    "citation": "Dalirrooyfard, Mina, et al. “Average-Case Hardness of Parity Problems: Orthogonal Vectors, k-SUM and More.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4613–43. Crossref, https://doi.org/10.1137/1.9781611978322.158."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.166",
+    "title": "A Sublinear-Time Algorithm for Nearly-Perfect Matchings in Regular Non-Bipartite Graphs.",
+    "venue": "soda 2025",
+    "citation": "Dani, Varsha, and Thomas P. Hayes. “A Sublinear-Time Algorithm for Nearly-Perfect Matchings in Regular Non-Bipartite Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4899–913. Crossref, https://doi.org/10.1137/1.9781611978322.166."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.90",
+    "title": "Solving Polynomial Equations Over Finite Fields.",
+    "venue": "soda 2025",
+    "citation": "Dell, Holger, et al. “Solving Polynomial Equations Over Finite Fields.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2779–803. Crossref, https://doi.org/10.1137/1.9781611978322.90."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.62",
+    "title": "Faster Linear Systems and Matrix Norm Approximation via Multi-level Sketched Preconditioning.",
+    "venue": "soda 2025",
+    "citation": "Dereziński, Michał, et al. “Faster Linear Systems and Matrix Norm Approximation via Multi-Level Sketched Preconditioning.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1972–2004. Crossref, https://doi.org/10.1137/1.9781611978322.62."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.116",
+    "title": "A Fast Algorithm for Computing Zigzag Representatives.",
+    "venue": "soda 2025",
+    "citation": "Dey, Tamal K., et al. “A Fast Algorithm for Computing Zigzag Representatives.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3530–46. Crossref, https://doi.org/10.1137/1.9781611978322.116."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.9",
+    "title": "Clustering Mixtures of Bounded Covariance Distributions Under Optimal Separation.",
+    "venue": "soda 2025",
+    "citation": "Diakonikolas, Ilias, et al. “Clustering Mixtures of Bounded Covariance Distributions Under Optimal Separation.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 288–322. Crossref, https://doi.org/10.1137/1.9781611978322.9."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.94",
+    "title": "Almost Tight Bounds for Differentially Private Densest Subgraph.",
+    "venue": "soda 2025",
+    "citation": "Dinitz, Michael, et al. “Almost Tight Bounds for Differentially Private Densest Subgraph.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2908–50. Crossref, https://doi.org/10.1137/1.9781611978322.94."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.121",
+    "title": "From Graph Properties to Graph Parameters: Tight Bounds for Counting on Small Subgraphs.",
+    "venue": "soda 2025",
+    "citation": "Döring, Simon, et al. “From Graph Properties to Graph Parameters: Tight Bounds for Counting on Small Subgraphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3637–76. Crossref, https://doi.org/10.1137/1.9781611978322.121."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.70",
+    "title": "Certificates in P and Subquadratic-Time Computation of Radius, Diameter, and all Eccentricities in Graphs.",
+    "venue": "soda 2025",
+    "citation": "Dragan, Feodor, et al. “Certificates in P and Subquadratic-Time Computation of Radius, Diameter, and All Eccentricities in Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2157–93. Crossref, https://doi.org/10.1137/1.9781611978322.70."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.168",
+    "title": "Randomized Greedy Online Edge Coloring Succeeds for Dense and Randomly-Ordered Graphs.",
+    "venue": "soda 2025",
+    "citation": "Dudeja, Aditi, et al. “Randomized Greedy Online Edge Coloring Succeeds for Dense and Randomly-Ordered Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4948–82. Crossref, https://doi.org/10.1137/1.9781611978322.168."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.110",
+    "title": "Planar Graphs in Blowups of Fans.",
+    "venue": "soda 2025",
+    "citation": "Dujmović, Vida, et al. “Planar Graphs in Blowups of Fans.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3382–91. Crossref, https://doi.org/10.1137/1.9781611978322.110."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.58",
+    "title": "Multi-Agent Combinatorial Contracts.",
+    "venue": "soda 2025",
+    "citation": "Dütting, Paul, et al. “Multi-Agent Combinatorial Contracts.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1857–91. Crossref, https://doi.org/10.1137/1.9781611978322.58."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.119",
+    "title": "Computing the second and third systoles of a combinatorial surface.",
+    "venue": "soda 2025",
+    "citation": "Ebbens, Matthijs, and Francis Lazarus. “Computing the Second and Third Systoles of a Combinatorial Surface.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3590–610. Crossref, https://doi.org/10.1137/1.9781611978322.119."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.20",
+    "title": "A Tight (3/2 + ∈ )-Approximation Algorithm for Demand Strip Packing.",
+    "venue": "soda 2025",
+    "citation": "Eberle, Franziska, et al. “A Tight (3/2 + ∈ )-Approximation Algorithm for Demand Strip Packing.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 641–99. Crossref, https://doi.org/10.1137/1.9781611978322.20."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.22",
+    "title": "Fully Dynamic Approximate Minimum Cut in Subpolynomial Time per Operation.",
+    "venue": "soda 2025",
+    "citation": "El-Hayek, Antoine, et al. “Fully Dynamic Approximate Minimum Cut in Subpolynomial Time per Operation.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 750–84. Crossref, https://doi.org/10.1137/1.9781611978322.22."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.138",
+    "title": "Faster two-dimensional pattern matching with k mismatches.",
+    "venue": "soda 2025",
+    "citation": "Ellert, Jonas, et al. “Faster Two-Dimensional Pattern Matching with k Mismatches.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4031–60. Crossref, https://doi.org/10.1137/1.9781611978322.138."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.104",
+    "title": "Highway Dimension: a Metric View.",
+    "venue": "soda 2025",
+    "citation": "Emil Feldmann, Andreas, and Arnold Filtser. “Highway Dimension: A Metric View.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3267–76. Crossref, https://doi.org/10.1137/1.9781611978322.104."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.156",
+    "title": "New Applications of 3SUM-Counting in Fine-Grained Complexity and Pattern Matching.",
+    "venue": "soda 2025",
+    "citation": "Fischer, Nick, et al. “New Applications of 3SUM-Counting in Fine-Grained Complexity and Pattern Matching.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4547–95. Crossref, https://doi.org/10.1137/1.9781611978322.156."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.155",
+    "title": "Sumsets, 3SUM, Subset Sum: Now for Real!",
+    "venue": "soda 2025",
+    "citation": "Fischer, Nick. “Sumsets, 3SUM, Subset Sum: Now for Real!” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4520–46. Crossref, https://doi.org/10.1137/1.9781611978322.155."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.160",
+    "title": "Inapproximability of Maximum Diameter Clustering for Few Clusters.",
+    "venue": "soda 2025",
+    "citation": "Fleischmann, Henry, et al. “Inapproximability of Maximum Diameter Clustering for Few Clusters.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4707–31. Crossref, https://doi.org/10.1137/1.9781611978322.160."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.43",
+    "title": "Fixed-Parameter Tractability of Hedge Cut.",
+    "venue": "soda 2025",
+    "citation": "Fomin, Fedor V., et al. “Fixed-Parameter Tractability of Hedge Cut.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1402–11. Crossref, https://doi.org/10.1137/1.9781611978322.43."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.7",
+    "title": "Dynamic Consistent k-Center Clustering with Optimal Recourse.",
+    "venue": "soda 2025",
+    "citation": "Forster, Sebastian, and Antonis Skarlatos. “Dynamic Consistent k-Center Clustering with Optimal Recourse.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 212–54. Crossref, https://doi.org/10.1137/1.9781611978322.7."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.83",
+    "title": "Approximating Competitive Equilibrium by Nash Welfare.",
+    "venue": "soda 2025",
+    "citation": "Garg, Jugal, et al. “Approximating Competitive Equilibrium by Nash Welfare.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2538–59. Crossref, https://doi.org/10.1137/1.9781611978322.83."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.36",
+    "title": "Constraint Satisfaction Problems with Advice.",
+    "venue": "soda 2025",
+    "citation": "Ghoshal, Suprovat, et al. “Constraint Satisfaction Problems with Advice.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1202–21. Crossref, https://doi.org/10.1137/1.9781611978322.36."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.86",
+    "title": "Clock Auctions Augmented with Unreliable Advice.",
+    "venue": "soda 2025",
+    "citation": "Gkatzelis, Vasilis, et al. “Clock Auctions Augmented with Unreliable Advice.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2629–55. Crossref, https://doi.org/10.1137/1.9781611978322.86."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.126",
+    "title": "Finding irrelevant vertices in linear time on bounded-genus graphs.",
+    "venue": "soda 2025",
+    "citation": "Golovach, Petr A., et al. “Finding Irrelevant Vertices in Linear Time on Bounded-Genus Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3762–74. Crossref, https://doi.org/10.1137/1.9781611978322.126."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.188",
+    "title": "Quantum Locally Recoverable Codes.",
+    "venue": "soda 2025",
+    "citation": "Golowic, Louis, and Venkatesan Guruswami. “Quantum Locally Recoverable Codes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5512–22. Crossref, https://doi.org/10.1137/1.9781611978322.188."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.191",
+    "title": "More Efficient Approximate k-wise Independent Permutations from Random Reversible Circuits via log-Sobolev Inequalities.",
+    "venue": "soda 2025",
+    "citation": "Gretta, Lucas, et al. “More Efficient Approximate k-Wise Independent Permutations from Random Reversible Circuits via Log-Sobolev Inequalities.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5582–98. Crossref, https://doi.org/10.1137/1.9781611978322.191."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.115",
+    "title": "Near-Optimal Relative Error Streaming Quantile Estimation via Elastic Compactors.",
+    "venue": "soda 2025",
+    "citation": "Gribelyuk, Elena, et al. “Near-Optimal Relative Error Streaming Quantile Estimation via Elastic Compactors.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3486–529. Crossref, https://doi.org/10.1137/1.9781611978322.115."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.51",
+    "title": "A Cut-Matching Game for Constant-Hop Expanders.",
+    "venue": "soda 2025",
+    "citation": "Haeupler, Bernhard, et al. “A Cut-Matching Game for Constant-Hop Expanders.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1651–78. Crossref, https://doi.org/10.1137/1.9781611978322.51."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.134",
+    "title": "Fast and Simple Sorting Using Partial Information.",
+    "venue": "soda 2025",
+    "citation": "Haeupler, Bernhard, et al. “Fast and Simple Sorting Using Partial Information.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3953–73. Crossref, https://doi.org/10.1137/1.9781611978322.134."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.85",
+    "title": "Platforms for Efficient and Incentive-Aware Collaboration.",
+    "venue": "soda 2025",
+    "citation": "Haghtalab, Nika, et al. “Platforms for Efficient and Incentive-Aware Collaboration.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2607–28. Crossref, https://doi.org/10.1137/1.9781611978322.85."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.164",
+    "title": "Gains-from-Trade in Bilateral Trade with a Broker.",
+    "venue": "soda 2025",
+    "citation": "Hajiaghayi, Ilya, et al. “Gains-from-Trade in Bilateral Trade with a Broker.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4827–60. Crossref, https://doi.org/10.1137/1.9781611978322.164."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.37",
+    "title": "New Prophet Inequalities via Poissonization and Sharding.",
+    "venue": "soda 2025",
+    "citation": "Harb, Elfarouk. “New Prophet Inequalities via Poissonization and Sharding.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1222–69. Crossref, https://doi.org/10.1137/1.9781611978322.37."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.186",
+    "title": "FPTAS for Holant Problems with Log-Concave Signatures.",
+    "venue": "soda 2025",
+    "citation": "He, Kun, et al. “FPTAS for Holant Problems with Log-Concave Signatures.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5468–503. Crossref, https://doi.org/10.1137/1.9781611978322.186."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.95",
+    "title": "Improved Differentially Private Continual Observation Using Group Algebra.",
+    "venue": "soda 2025",
+    "citation": "Henzinger, Monika, and Jalaj Upadhyay. “Improved Differentially Private Continual Observation Using Group Algebra.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2951–70. Crossref, https://doi.org/10.1137/1.9781611978322.95."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.8",
+    "title": "Clustering to Minimize Cluster-Aware Norm Objectives.",
+    "venue": "soda 2025",
+    "citation": "Herold, Martin G., et al. “Clustering to Minimize Cluster-Aware Norm Objectives.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 255–87. Crossref, https://doi.org/10.1137/1.9781611978322.8."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.107",
+    "title": "Weak coloring numbers of minor-closed graph classes.",
+    "venue": "soda 2025",
+    "citation": "Hodor, Jçdrzej, et al. “Weak Coloring Numbers of Minor-Closed Graph Classes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3325–34. Crossref, https://doi.org/10.1137/1.9781611978322.107."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.150",
+    "title": "New Separations and Reductions for Directed Hopsets and Preservers.",
+    "venue": "soda 2025",
+    "citation": "Hoppenworth, Gary, et al. “New Separations and Reductions for Directed Hopsets and Preservers.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4405–43. Crossref, https://doi.org/10.1137/1.9781611978322.150."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.40",
+    "title": "Designing Automated Market Makers for Combinatorial Securities: A Geometric Viewpoint.",
+    "venue": "soda 2025",
+    "citation": "Hossain, Prommy Sultana, et al. “Designing Automated Market Makers for Combinatorial Securities: A Geometric Viewpoint.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1329–65. Crossref, https://doi.org/10.1137/1.9781611978322.40."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.161",
+    "title": "Coresets for Constrained Clustering: General Assignment Constraints and Improved Size Bounds.",
+    "venue": "soda 2025",
+    "citation": "Huang, Lingxiao, et al. “Coresets for Constrained Clustering: General Assignment Constraints and Improved Size Bounds.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4732–82. Crossref, https://doi.org/10.1137/1.9781611978322.161."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.178",
+    "title": "Faster single-source shortest paths with negative real weights via proper hop distance.",
+    "venue": "soda 2025",
+    "citation": "Huang, Yufan, et al. “Faster Single-Source Shortest Paths with Negative Real Weights via Proper Hop Distance.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5239–44. Crossref, https://doi.org/10.1137/1.9781611978322.178."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.50",
+    "title": "Eulerian Graph Sparsification by Effective Resistance Decomposition.",
+    "venue": "soda 2025",
+    "citation": "Jambulapati, Arun, et al. “Eulerian Graph Sparsification by Effective Resistance Decomposition.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1607–50. Crossref, https://doi.org/10.1137/1.9781611978322.50."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.182",
+    "title": "Potential Hessian Ascent: The Sherrington-Kirkpatrick Model.",
+    "venue": "soda 2025",
+    "citation": "Jekel, David, et al. “Potential Hessian Ascent: The Sherrington-Kirkpatrick Model.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5307–87. Crossref, https://doi.org/10.1137/1.9781611978322.182."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.117",
+    "title": "Minimum Convex Hull and Maximum Overlap of Two Convex Polytopes.",
+    "venue": "soda 2025",
+    "citation": "Jung, Mook Kwon, et al. “Minimum Convex Hull and Maximum Overlap of Two Convex Polytopes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3547–61. Crossref, https://doi.org/10.1137/1.9781611978322.117."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.147",
+    "title": "Subquadratic algorithms in minor-free digraphs: (weighted) distance oracles, decrementai reachability, and more.",
+    "venue": "soda 2025",
+    "citation": "Karczmarz, Adam, and Da Wei Zheng. “Subquadratic Algorithms in Minor-Free Digraphs: (Weighted) Distance Oracles, Decremental Reachability, and More.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4338–51. Crossref, https://doi.org/10.1137/1.9781611978322.147."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.89",
+    "title": "On the Decidability of Presburger Arithmetic Expanded with Powers.",
+    "venue": "soda 2025",
+    "citation": "Karimov, Toghrul, et al. “On the Decidability of Presburger Arithmetic Expanded with Powers.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2755–78. Crossref, https://doi.org/10.1137/1.9781611978322.89."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.106",
+    "title": "An analogue of Reed&apos;s conjecture for digraphs.",
+    "venue": "soda 2025",
+    "citation": "Kawarabayashi, Ken-ichi, and Lucas Picasarri-Arrieta. “An Analogue of Reed’s Conjecture for Digraphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3310–24. Crossref, https://doi.org/10.1137/1.9781611978322.106."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.27",
+    "title": "Triply efficient shadow tomography.",
+    "venue": "soda 2025",
+    "citation": "King, Robbie, et al. “Triply Efficient Shadow Tomography.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 914–46. Crossref, https://doi.org/10.1137/1.9781611978322.27."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.15",
+    "title": "Near-Optimal-Time Quantum Algorithms for Approximate Pattern Matching.",
+    "venue": "soda 2025",
+    "citation": "Kociumaka, Tomasz, et al. “Near-Optimal-Time Quantum Algorithms for Approximate Pattern Matching.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 517–34. Crossref, https://doi.org/10.1137/1.9781611978322.15."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.148",
+    "title": "Having Hope in Missing Spanners: New Distance Preservers and Light Hopsets.",
+    "venue": "soda 2025",
+    "citation": "Kogan, Shimon, and Merav Parter. “Having Hope in Missing Spanners: New Distance Preservers and Light Hopsets.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4352–74. Crossref, https://doi.org/10.1137/1.9781611978322.148."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.60",
+    "title": "An Efficient Uniqueness Theorem for Overcomplete Tensor Decomposition.",
+    "venue": "soda 2025",
+    "citation": "Koiran, Pascal. “An Efficient Uniqueness Theorem for Overcomplete Tensor Decomposition.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1909–32. Crossref, https://doi.org/10.1137/1.9781611978322.60."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.181",
+    "title": "Rényi-infinity constrained sampling with d3 membership queries.",
+    "venue": "soda 2025",
+    "citation": "Kook, Yunbum, and Matthew S. Zhang. “Rényi-Infinity Constrained Sampling with d3 Membership Queries.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5278–306. Crossref, https://doi.org/10.1137/1.9781611978322.181."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.31",
+    "title": "Lipschitz Continuous Algorithms for Covering Problems.",
+    "venue": "soda 2025",
+    "citation": "Kumabe, Soh, and Yuichi Yoshida. “Lipschitz Continuous Algorithms for Covering Problems.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1057–93. Crossref, https://doi.org/10.1137/1.9781611978322.31."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.133",
+    "title": "Efficient d-ary Cuckoo Hashing at High Load Factors by Bubbling Up.",
+    "venue": "soda 2025",
+    "citation": "Kuszmaul, William, and Michael Mitzenmacher. “Efficient d-Ary Cuckoo Hashing at High Load Factors by Bubbling Up.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3931–52. Crossref, https://doi.org/10.1137/1.9781611978322.133."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.135",
+    "title": "Tight Bounds and Phase Transitions for Incremental and Dynamic Retrieval.",
+    "venue": "soda 2025",
+    "citation": "Kuszmaul, William, et al. “Tight Bounds and Phase Transitions for Incremental and Dynamic Retrieval.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3974–97. Crossref, https://doi.org/10.1137/1.9781611978322.135."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.47",
+    "title": "The Primal Pathwidth SETH.",
+    "venue": "soda 2025",
+    "citation": "Lampis, Michael. “The Primal Pathwidth SETH.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1494–564. Crossref, https://doi.org/10.1137/1.9781611978322.47."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.93",
+    "title": "Local Lipschitz Filters for Bounded-Range Functions with Applications to Arbitrary Real-Valued Functions.",
+    "venue": "soda 2025",
+    "citation": "Lange, Jane, et al. “Local Lipschitz Filters for Bounded-Range Functions with Applications to Arbitrary Real-Valued Functions.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2881–907. Crossref, https://doi.org/10.1137/1.9781611978322.93."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.190",
+    "title": "Improved Explicit Near-Optimal Codes in the High-Noise Regimes.",
+    "venue": "soda 2025",
+    "citation": "Li, Xin, and Songtao Mao. “Improved Explicit Near-Optimal Codes in the High-Noise Regimes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5560–81. Crossref, https://doi.org/10.1137/1.9781611978322.190."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.28",
+    "title": "On Estimating the Trace of Quantum State Powers.",
+    "venue": "soda 2025",
+    "citation": "Liu, Yupan, and Qisheng Wang. “On Estimating the Trace of Quantum State Powers.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 947–93. Crossref, https://doi.org/10.1137/1.9781611978322.28."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.44",
+    "title": "Crossing Number in Slightly Superexponential Time (Extended Abstract).",
+    "venue": "soda 2025",
+    "citation": "Lokshtanov, Daniel, et al. “Crossing Number in Slightly Superexponential Time (Extended Abstract).” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1412–24. Crossref, https://doi.org/10.1137/1.9781611978322.44."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.48",
+    "title": "Parameterized Approximation for Capacitated d-Hitting Set with Hard Capacities.",
+    "venue": "soda 2025",
+    "citation": "Lokshtanov, Daniel, et al. “Parameterized Approximation for Capacitated d-Hitting Set with Hard Capacities.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1565–92. Crossref, https://doi.org/10.1137/1.9781611978322.48."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.1",
+    "title": "Connectivity Labeling Schemes for Edge and Vertex Faults via Expander Hierarchies.",
+    "venue": "soda 2025",
+    "citation": "Long, Yaowei, et al. “Connectivity Labeling Schemes for Edge and Vertex Faults via Expander Hierarchies.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1–47. Crossref, https://doi.org/10.1137/1.9781611978322.1."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.75",
+    "title": "The Change-of-Measure Method, Block Lewis Weights, and Approximating Matrix Block Norms.",
+    "venue": "soda 2025",
+    "citation": "Manoj, Naren Sarayu, and Max Ovsiankin. “The Change-of-Measure Method, Block Lewis Weights, and Approximating Matrix Block Norms.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2252–300. Crossref, https://doi.org/10.1137/1.9781611978322.75."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.154",
+    "title": "A topological proof of the Hell-Nešetřil dichotomy.",
+    "venue": "soda 2025",
+    "citation": "Meyer, Sebastian, and Jakub Opršal. “A Topological Proof of the Hell-Nešetřil Dichotomy.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4507–19. Crossref, https://doi.org/10.1137/1.9781611978322.154."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.38",
+    "title": "Prophet Inequalities: Competing with the Top ℓ Items is Easy.",
+    "venue": "soda 2025",
+    "citation": "Molina, Mathieu, et al. “Prophet Inequalities: Competing with the Top ℓ Items Is Easy.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1270–307. Crossref, https://doi.org/10.1137/1.9781611978322.38."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.130",
+    "title": "Putting Off the Catching Up: Online Joint Replenishment Problem with Holding and Backlog Costs.",
+    "venue": "soda 2025",
+    "citation": "Moseley, Benjamin, et al. “Putting Off the Catching Up: Online Joint Replenishment Problem with Holding and Backlog Costs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3865–83. Crossref, https://doi.org/10.1137/1.9781611978322.130."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.189",
+    "title": "Locally Testable Tree Codes.",
+    "venue": "soda 2025",
+    "citation": "Moud, Tamer, et al. “Locally Testable Tree Codes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5523–59. Crossref, https://doi.org/10.1137/1.9781611978322.189."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.100",
+    "title": "Online Dependent Rounding Schemes for Bipartite Matchings, with.",
+    "venue": "soda 2025",
+    "citation": "Naor, Joseph (Seffi), et al. “Online Dependent Rounding Schemes for Bipartite Matchings, With.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3116–54. Crossref, https://doi.org/10.1137/1.9781611978322.100."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.16",
+    "title": "A Subexponential Time Algorithm for Makespan Scheduling of Unit Jobs with Precedence Constraints.",
+    "venue": "soda 2025",
+    "citation": "Nederlof, Jesper, et al. “A Subexponential Time Algorithm for Makespan Scheduling of Unit Jobs with Precedence Constraints.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 535–52. Crossref, https://doi.org/10.1137/1.9781611978322.16."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.74",
+    "title": "Complexity of polytope diameters via perfect matchings.",
+    "venue": "soda 2025",
+    "citation": "Nöbel, Christian, and Raphael Steiner. “Complexity of Polytope Diameters via Perfect Matchings.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2234–51. Crossref, https://doi.org/10.1137/1.9781611978322.74."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.139",
+    "title": "Parks and Recreation: Color Fault-Tolerant Spanners Made Local.",
+    "venue": "soda 2025",
+    "citation": "Parter, Merav, et al. “Parks and Recreation: Color Fault-Tolerant Spanners Made Local.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4061–94. Crossref, https://doi.org/10.1137/1.9781611978322.139."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.2",
+    "title": "A Dichotomy Hierarchy for Linear Time Subgraph Counting in Bounded Degeneracy Graphs.",
+    "venue": "soda 2025",
+    "citation": "Paul-Pena, Daniel, and C. Seshadhri. “A Dichotomy Hierarchy for Linear Time Subgraph Counting in Bounded Degeneracy Graphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 48–87. Crossref, https://doi.org/10.1137/1.9781611978322.2."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.152",
+    "title": "A Refutation of the Pach-Tardos Conjecture for 0-1 Matrices.",
+    "venue": "soda 2025",
+    "citation": "Pettie, Seth, and Gábor Tardos. “A Refutation of the Pach-Tardos Conjecture for 0-1 Matrices.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 4462–83. Crossref, https://doi.org/10.1137/1.9781611978322.152."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.112",
+    "title": "Universal Perfect Samplers for Incremental Streams.",
+    "venue": "soda 2025",
+    "citation": "Pettie, Seth, and Dingyu Wang. “Universal Perfect Samplers for Incremental Streams.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3409–22. Crossref, https://doi.org/10.1137/1.9781611978322.112."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.30",
+    "title": "Polynomial-Time Classical Simulation of Noisy IQP Circuits with Constant Depth.",
+    "venue": "soda 2025",
+    "citation": "Rajakumar, Joel, et al. “Polynomial-Time Classical Simulation of Noisy IQP Circuits with Constant Depth.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 1037–56. Crossref, https://doi.org/10.1137/1.9781611978322.30."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.120",
+    "title": "An Efficient Regularity Lemma for Semi-Algebraic Hypergraphs.",
+    "venue": "soda 2025",
+    "citation": "Rubin, Natan. “An Efficient Regularity Lemma for Semi-Algebraic Hypergraphs.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3611–36. Crossref, https://doi.org/10.1137/1.9781611978322.120."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.175",
+    "title": "Fine-Grained Optimality of Partially Dynamic Shortest Paths and More.",
+    "venue": "soda 2025",
+    "citation": "Saha, Barna, et al. “Fine-Grained Optimality of Partially Dynamic Shortest Paths and More.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5147–90. Crossref, https://doi.org/10.1137/1.9781611978322.175."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.124",
+    "title": "Parameterizing the quantification of CMSO: model checking on minor-closed graph classes.",
+    "venue": "soda 2025",
+    "citation": "Sau, Ignasi, et al. “Parameterizing the Quantification of CMSO: Model Checking on Minor-Closed Graph Classes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3728–42. Crossref, https://doi.org/10.1137/1.9781611978322.124."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.111",
+    "title": "Streaming Algorithms via Local Algorithms for Maximum Directed Cut.",
+    "venue": "soda 2025",
+    "citation": "Saxena, Raghuvansh R., et al. “Streaming Algorithms via Local Algorithms for Maximum Directed Cut.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 3392–408. Crossref, https://doi.org/10.1137/1.9781611978322.111."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.26",
+    "title": "Quartic quantum speedups for planted inference.",
+    "venue": "soda 2025",
+    "citation": "Schmidhuber, Alexander, et al. “Quartic Quantum Speedups for Planted Inference.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 905–13. Crossref, https://doi.org/10.1137/1.9781611978322.26."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.192",
+    "title": "Hermitian Diagonalization in Linear Precision.",
+    "venue": "soda 2025",
+    "citation": "Shah, Rikhav. “Hermitian Diagonalization in Linear Precision.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5599–615. Crossref, https://doi.org/10.1137/1.9781611978322.192."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.64",
+    "title": "Improved List Size for Folded Reed-Solomon Codes.",
+    "venue": "soda 2025",
+    "citation": "Srivastava, Shashank. “Improved List Size for Folded Reed-Solomon Codes.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2040–50. Crossref, https://doi.org/10.1137/1.9781611978322.64."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.14",
+    "title": "Tight Sampling Bounds for Eigenvalue Approximation.",
+    "venue": "soda 2025",
+    "citation": "Swartworth, William, and David P. Woodruff. “Tight Sampling Bounds for Eigenvalue Approximation.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 489–516. Crossref, https://doi.org/10.1137/1.9781611978322.14."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.72",
+    "title": "Testing Approximate Stationarity Concepts for Piecewise Affine Functions.",
+    "venue": "soda 2025",
+    "citation": "Tian, Lai, and Anthony Man-Cho So. “Testing Approximate Stationarity Concepts for Piecewise Affine Functions.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2213–24. Crossref, https://doi.org/10.1137/1.9781611978322.72."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.69",
+    "title": "(Almost) Ruling Out SETH Lower Bounds for All-Pairs Max-Flow.",
+    "venue": "soda 2025",
+    "citation": "Trabeisi, Ohad. “(Almost) Ruling Out SETH Lower Bounds for All-Pairs Max-Flow.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2132–56. Crossref, https://doi.org/10.1137/1.9781611978322.69."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.174",
+    "title": "A Discrete Analog of Tutte&apos;s Barycentric Embeddings on Surfaces.",
+    "venue": "soda 2025",
+    "citation": "Verdière, Éric Colin de, et al. “A Discrete Analog of Tutte’s Barycentric Embeddings on Surfaces.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5114–46. Crossref, https://doi.org/10.1137/1.9781611978322.174."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.21",
+    "title": "Tree-Packing Revisited: Faster Fully Dynamic Min-Cut and Arboricity.",
+    "venue": "soda 2025",
+    "citation": "de Vos, Tijn, and Aleksander B. G. Christiansen. “Tree-Packing Revisited: Faster Fully Dynamic Min-Cut and Arboricity.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 700–49. Crossref, https://doi.org/10.1137/1.9781611978322.21."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.66",
+    "title": "Tight Streaming Lower Bounds for Deterministic Approximate Counting.",
+    "venue": "soda 2025",
+    "citation": "Wang, Yichuan. “Tight Streaming Lower Bounds for Deterministic Approximate Counting.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 2076–94. Crossref, https://doi.org/10.1137/1.9781611978322.66."
+  },
+  {
+    "doi": "10.1137/1.9781611978322.176",
+    "title": "All-Hops Shortest Paths.",
+    "venue": "soda 2025",
+    "citation": "Williams, Virginia Vassilevska, et al. “All-Hops Shortest Paths.” Proceedings of the 2025 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA), Society for Industrial and Applied Mathematics, Jan. 2025, pp. 5191–206. Crossref, https://doi.org/10.1137/1.9781611978322.176."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.40",
+    "title": "Identity-Preserving Lax Extensions and Where to Find Them.",
+    "venue": "stacs 2025",
+    "citation": "Goncharov, Sergey, et al. Identity-Preserving Lax Extensions and Where to Find Them. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.40."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.5",
+    "title": "Parameterized Saga of First-Fit and Last-Fit Coloring.",
+    "venue": "stacs 2025",
+    "citation": "Agrawal, Akanksha, et al. Parameterized Saga of First-Fit and Last-Fit Coloring. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.5."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.50",
+    "title": "Designing Exploration Contracts.",
+    "venue": "stacs 2025",
+    "citation": "Hoefer, Martin, et al. Designing Exploration Contracts. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.50."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.75",
+    "title": "Canonical Labeling of Sparse Random Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Verbitsky, Oleg, and Maksim Zhukovskii. Canonical Labeling of Sparse Random Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.75."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.76",
+    "title": "Dynamic Unit-Disk Range Reporting.",
+    "venue": "stacs 2025",
+    "citation": "Wang, Haitao, and Yiming Zhao. Dynamic Unit-Disk Range Reporting. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.76."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.3",
+    "title": "Algebras for Automata: Reasoning with Regularity (Invited Talk).",
+    "venue": "stacs 2025",
+    "citation": "Das, Anupam. Algebras for Automata: Reasoning with Regularity (Invited Talk). With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.3."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.38",
+    "title": "Two-Dimensional Longest Common Extension Queries in Compact Space.",
+    "venue": "stacs 2025",
+    "citation": "Ganguly, Arnab, et al. Two-Dimensional Longest Common Extension Queries in Compact Space. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.38."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.6",
+    "title": "Twin-Width One.",
+    "venue": "stacs 2025",
+    "citation": "Ahn, Jungho, et al. Twin-Width One. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.6."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.7",
+    "title": "Faster Edge Coloring by Partition Sieving.",
+    "venue": "stacs 2025",
+    "citation": "Akmal, Shyan, and Tomohiro Koana. Faster Edge Coloring by Partition Sieving. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.7."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.8",
+    "title": "Tropical Proof Systems: Between R(CP) and Resolution.",
+    "venue": "stacs 2025",
+    "citation": "Alekseev, Yaroslav, et al. Tropical Proof Systems: Between R(CP) and Resolution. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.8."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.9",
+    "title": "Improved Approximation Algorithms for (1, 2)-TSP and Max-TSP Using Path Covers in the Semi-Streaming Model.",
+    "venue": "stacs 2025",
+    "citation": "Alipour, Sharareh, et al. Improved Approximation Algorithms for (1,2)-TSP and Max-TSP Using Path Covers in the Semi-Streaming Model. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.9."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.10",
+    "title": "Monotone Weak Distributive Laws over the Lifted Powerset Monad in Categories of Algebras.",
+    "venue": "stacs 2025",
+    "citation": "Aristote, Quentin. Monotone Weak Distributive Laws over the Lifted Powerset Monad in Categories of Algebras. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.10."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.11",
+    "title": "Generalized Inner Product Estimation with Limited Quantum Communication.",
+    "venue": "stacs 2025",
+    "citation": "Arunachalam, Srinivasan, and Louis Schatzki. Generalized Inner Product Estimation with Limited Quantum Communication. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.11."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.1",
+    "title": "Proof Complexity and Its Relations to SAT Solving (Invited Talk).",
+    "venue": "stacs 2025",
+    "citation": "Atserias, Albert. Proof Complexity and Its Relations to SAT Solving (Invited Talk). With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.1."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.12",
+    "title": "Results on H-Freeness Testing in Graphs of Bounded r-Admissibility.",
+    "venue": "stacs 2025",
+    "citation": "Awofeso, Christine, et al. Results on H-Freeness Testing in Graphs of Bounded r-Admissibility. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.12."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.13",
+    "title": "Hyperbolic Random Graphs: Clique Number and Degeneracy with Implications for Colouring.",
+    "venue": "stacs 2025",
+    "citation": "Baguley, Samuel, et al. Hyperbolic Random Graphs: Clique Number and Degeneracy with Implications for Colouring. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.13."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.14",
+    "title": "Multivariate Exploration of Metric Dilation.",
+    "venue": "stacs 2025",
+    "citation": "Banik, Aritra, et al. Multivariate Exploration of Metric Dilation. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.14."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.15",
+    "title": "Structure-Guided Automated Reasoning.",
+    "venue": "stacs 2025",
+    "citation": "Bannach, Max, and Markus Hecher. Structure-Guided Automated Reasoning. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.15."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.16",
+    "title": "Listing Spanning Trees of Outerplanar Graphs by Pivot-Exchanges.",
+    "venue": "stacs 2025",
+    "citation": "Behrooznia, Nastaran, and Torsten Mütze. Listing Spanning Trees of Outerplanar Graphs by Pivot-Exchanges. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.16."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.17",
+    "title": "Tight Approximation and Kernelization Bounds for Vertex-Disjoint Shortest Paths.",
+    "venue": "stacs 2025",
+    "citation": "Bentert, Matthias, et al. Tight Approximation and Kernelization Bounds for Vertex-Disjoint Shortest Paths. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.17."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.18",
+    "title": "Online Disjoint Set Covers: Randomization Is Not Necessary.",
+    "venue": "stacs 2025",
+    "citation": "Bienkowski, Marcin, et al. Online Disjoint Set Covers: Randomization Is Not Necessary. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.18."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.19",
+    "title": "The Complexity of Learning LTL, CTL and ATL Formulas.",
+    "venue": "stacs 2025",
+    "citation": "Bordais, Benjamin, et al. The Complexity of Learning LTL, CTL and ATL Formulas. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.19."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.20",
+    "title": "On Cascades of Reset Automata.",
+    "venue": "stacs 2025",
+    "citation": "Borelli, Roberto, et al. On Cascades of Reset Automata. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.20."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.21",
+    "title": "Computability of Extender Sets in Multidimensional Subshifts.",
+    "venue": "stacs 2025",
+    "citation": "Callard, Antonin, et al. Computability of Extender Sets in Multidimensional Subshifts. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.21."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.22",
+    "title": "CMSO-Transducing Tree-Like Graph Decompositions.",
+    "venue": "stacs 2025",
+    "citation": "Campbell, Rutger, et al. CMSO-Transducing Tree-Like Graph Decompositions. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.22."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.23",
+    "title": "How to Play the Accordion: Uniformity and the (Non-)Conservativity of the Linear Approximation of the λ-Calculus.",
+    "venue": "stacs 2025",
+    "citation": "Cerda, Rémy, and Lionel Vaux Auclair. How to Play the Accordion: Uniformity and the (Non-)Conservativity of the Linear Approximation of the λ-Calculus. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.23."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.24",
+    "title": "A Deterministic Approach to Shortest Path Restoration in Edge Faulty Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Choudhary, Keerti, and Rishabh Dhiman. A Deterministic Approach to Shortest Path Restoration in Edge Faulty Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.24."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.25",
+    "title": "Local Density and Its Distributed Approximation.",
+    "venue": "stacs 2025",
+    "citation": "Christiansen, Aleksander Bjørn, et al. Local Density and Its Distributed Approximation. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.25."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.26",
+    "title": "Toward Better Depth Lower Bounds: Strong Composition of XOR and a Random Function.",
+    "venue": "stacs 2025",
+    "citation": "Chukhin, Nikolai, et al. Toward Better Depth Lower Bounds: Strong Composition of XOR and a Random Function. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.26."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.27",
+    "title": "Local Equivalence of Stabilizer States: A Graphical Characterisation.",
+    "venue": "stacs 2025",
+    "citation": "Claudet, Nathan, and Simon Perdrix. Local Equivalence of Stabilizer States: A Graphical Characterisation. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.27."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.28",
+    "title": "Can You Link Up With Treewidth?",
+    "venue": "stacs 2025",
+    "citation": "Curticapean, Radu, et al. Can You Link Up With Treewidth? With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.28."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.2",
+    "title": "A Strongly Polynomial Algorithm for Linear Programs with at Most Two Non-Zero Entries per Row or Column (Invited Talk).",
+    "venue": "stacs 2025",
+    "citation": "Dadush, Daniel, et al. A Strongly Polynomial Algorithm for Linear Programs with at Most Two Non-Zero Entries per Row or Column (Invited Talk). With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.2."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.29",
+    "title": "Noisy (Binary) Searching: Simple, Fast and Correct.",
+    "venue": "stacs 2025",
+    "citation": "Dereniowski, Dariusz, et al. Noisy (Binary) Searching: Simple, Fast and Correct. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.29."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.30",
+    "title": "Being Efficient in Time, Space, and Workload: a Self-Stabilizing Unison and Its Consequences.",
+    "venue": "stacs 2025",
+    "citation": "Devismes, Stéphane, et al. Being Efficient in Time, Space, and Workload: A Self-Stabilizing Unison and Its Consequences. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.30."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.31",
+    "title": "Efficient Approximation Schemes for Scheduling on a Stochastic Number of Machines.",
+    "venue": "stacs 2025",
+    "citation": "Epstein, Leah, and Asaf Levin. Efficient Approximation Schemes for Scheduling on a Stochastic Number of Machines. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.31."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.32",
+    "title": "A Faster Algorithm for Constrained Correlation Clustering.",
+    "venue": "stacs 2025",
+    "citation": "Fischer, Nick, et al. A Faster Algorithm for Constrained Correlation Clustering. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.32."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.33",
+    "title": "Metric Dimension and Geodetic Set Parameterized by Vertex Cover.",
+    "venue": "stacs 2025",
+    "citation": "Foucaud, Florent, et al. Metric Dimension and Geodetic Set Parameterized by Vertex Cover. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.33."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.34",
+    "title": "Agreement Tasks in Fault-Prone Synchronous Networks of Arbitrary Structure.",
+    "venue": "stacs 2025",
+    "citation": "Fraigniaud, Pierre, et al. Agreement Tasks in Fault-Prone Synchronous Networks of Arbitrary Structure. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.34."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.35",
+    "title": "Dimension-Free Parameterized Approximation Schemes for Hybrid Clustering.",
+    "venue": "stacs 2025",
+    "citation": "Gadekar, Ameet, and Tanmay Inamdar. Dimension-Free Parameterized Approximation Schemes for Hybrid Clustering. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.35."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.36",
+    "title": "MaxMin Separation Problems: FPT Algorithms for st-Separator and Odd Cycle Transversal.",
+    "venue": "stacs 2025",
+    "citation": "Gaikwad, Ajinkya, et al. MaxMin Separation Problems: FPT Algorithms for St-Separator and Odd Cycle Transversal. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.36."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.37",
+    "title": "On the Existential Theory of the Reals Enriched with Integer Powers of a Computable Number.",
+    "venue": "stacs 2025",
+    "citation": "Gallego-Hernández, Jorge, and Alessio Mansutti. On the Existential Theory of the Reals Enriched with Integer Powers of a Computable Number. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.37."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.39",
+    "title": "A Quasi-Polynomial Time Algorithm for Multi-Arrival on Tree-Like Multigraphs.",
+    "venue": "stacs 2025",
+    "citation": "Ghorbani, Ebrahim, et al. A Quasi-Polynomial Time Algorithm for Multi-Arrival on Tree-Like Multigraphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.39."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.41",
+    "title": "Residue Domination in Bounded-Treewidth Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Greilhuber, Jakob, et al. Residue Domination in Bounded-Treewidth Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.41."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.42",
+    "title": "Local Enumeration: The Not-All-Equal Case.",
+    "venue": "stacs 2025",
+    "citation": "Gurumukhani, Mohit, et al. Local Enumeration: The Not-All-Equal Case. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.42."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.43",
+    "title": "Approximating Densest Subgraph in Geometric Intersection Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Har-Peled, Sariel, and Saladi Rahul. Approximating Densest Subgraph in Geometric Intersection Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.43."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.44",
+    "title": "Independence and Domination on Bounded-Treewidth Graphs: Integer, Rational, and Irrational Distances.",
+    "venue": "stacs 2025",
+    "citation": "Hartmann, Tim A., and Dániel Marx. Independence and Domination on Bounded-Treewidth Graphs: Integer, Rational, and Irrational Distances. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.44."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.45",
+    "title": "Forbidden Patterns in Mixed Linear Layouts.",
+    "venue": "stacs 2025",
+    "citation": "Haun, Deborah, et al. Forbidden Patterns in Mixed Linear Layouts. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.45."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.46",
+    "title": "Sampling Unlabeled Chordal Graphs in Expected Polynomial Time.",
+    "venue": "stacs 2025",
+    "citation": "Hébert-Johnson, Úrsula, and Daniel Lokshtanov. Sampling Unlabeled Chordal Graphs in Expected Polynomial Time. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.46."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.47",
+    "title": "Minimizing the Number of Tardy Jobs with Uniform Processing Times on Parallel Machines.",
+    "venue": "stacs 2025",
+    "citation": "Heeger, Klaus, and Hendrik Molter. Minimizing the Number of Tardy Jobs with Uniform Processing Times on Parallel Machines. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.47."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.49",
+    "title": "Cycle Counting Under Local Differential Privacy for Degeneracy-Bounded Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Hillebrand, Quentin, et al. Cycle Counting Under Local Differential Privacy for Degeneracy-Bounded Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.49."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.51",
+    "title": "Protecting the Connectivity of a Graph Under Non-Uniform Edge Failures.",
+    "venue": "stacs 2025",
+    "citation": "Hommelsheim, Felix, et al. Protecting the Connectivity of a Graph Under Non-Uniform Edge Failures. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.51."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.52",
+    "title": "Polynomial Kernel and Incompressibility for Prison-Free Edge Deletion and Completion.",
+    "venue": "stacs 2025",
+    "citation": "Houari-Durand, Séhane Bel, et al. Polynomial Kernel and Incompressibility for Prison-Free Edge Deletion and Completion. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.52."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.53",
+    "title": "On Read-k Projections of the Determinant.",
+    "venue": "stacs 2025",
+    "citation": "Hrubeš, Pavel, and Pushkar S. Joglekar. On Read-k Projections of the Determinant. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.53."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.54",
+    "title": "Multidimensional Quantum Walks, Recursion, and Quantum Divide &amp; Conquer.",
+    "venue": "stacs 2025",
+    "citation": "Jeffery, Stacey, and Galina Pass. Multidimensional Quantum Walks, Recursion, and Quantum Divide & Conquer. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.54."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.55",
+    "title": "Modal Separation of Fixpoint Formulae.",
+    "venue": "stacs 2025",
+    "citation": "Jung, Jean Christoph, and Jędrzej Kołodziejski. Modal Separation of Fixpoint Formulae. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.55."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.56",
+    "title": "Transforming Stacks into Queues: Mixed and Separated Layouts of Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Katheder, Julia, et al. Transforming Stacks into Queues: Mixed and Separated Layouts of Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.56."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.57",
+    "title": "Approximate Minimum Tree Cover in All Symmetric Monotone Norms Simultaneously.",
+    "venue": "stacs 2025",
+    "citation": "Kaul, Matthias, et al. Approximate Minimum Tree Cover in All Symmetric Monotone Norms Simultaneously. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.57."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.58",
+    "title": "Violating Constant Degree Hypothesis Requires Breaking Symmetry.",
+    "venue": "stacs 2025",
+    "citation": "Kawałek, Piotr, and Armin Weiß. Violating Constant Degree Hypothesis Requires Breaking Symmetry. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.58."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.59",
+    "title": "Online Matching with Delays and Size-Based Costs.",
+    "venue": "stacs 2025",
+    "citation": "Kawase, Yasushi, and Tomohiro Nakayoshi. Online Matching with Delays and Size-Based Costs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.59."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.60",
+    "title": "Modular Counting CSP: Reductions and Algorithms.",
+    "venue": "stacs 2025",
+    "citation": "Kazeminia, Amirhossein, and Andrei A. Bulatov. Modular Counting CSP: Reductions and Algorithms. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.60."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.61",
+    "title": "Efficiently Computing the Minimum Rank of a Matrix in a Monoid of Zero-One Matrices.",
+    "venue": "stacs 2025",
+    "citation": "Kiefer, Stefan, and Andrew Ryzhikov. Efficiently Computing the Minimum Rank of a Matrix in a Monoid of Zero-One Matrices. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.61."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.62",
+    "title": "Faster Algorithms on Linear Delta-Matroids.",
+    "venue": "stacs 2025",
+    "citation": "Koana, Tomohiro, and Magnus Wahlström. Faster Algorithms on Linear Delta-Matroids. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.62."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.63",
+    "title": "Approximation of Spanning Tree Congestion Using Hereditary Bisection.",
+    "venue": "stacs 2025",
+    "citation": "Kolman, Petr. Approximation of Spanning Tree Congestion Using Hereditary Bisection. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.63."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.64",
+    "title": "Cluster Editing on Cographs and Related Classes.",
+    "venue": "stacs 2025",
+    "citation": "Lafond, Manuel, et al. Cluster Editing on Cographs and Related Classes. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.64."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.65",
+    "title": "On Average Baby PIH and Its Applications.",
+    "venue": "stacs 2025",
+    "citation": "Liu, Yuwei, et al. On Average Baby PIH and Its Applications. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.65."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.66",
+    "title": "The Hardness of Decision Tree Complexity.",
+    "venue": "stacs 2025",
+    "citation": "Loff, Bruno, and Alexey Milovanov. The Hardness of Decision Tree Complexity. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.66."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.67",
+    "title": "Commutative ℕ-Rational Series of Polynomial Growth.",
+    "venue": "stacs 2025",
+    "citation": "Lopez, Aliaume. Commutative ℕ-Rational Series of Polynomial Growth. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.67."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.48",
+    "title": "Subshifts Defined by Nondeterministic and Alternating Plane-Walking Automata.",
+    "venue": "stacs 2025",
+    "citation": "Hellouin de Menibus, Benjamin, and Pacôme Perrotin. Subshifts Defined by Nondeterministic and Alternating Plane-Walking Automata. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.48."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.68",
+    "title": "Slightly Non-Linear Higher-Order Tree Transducers.",
+    "venue": "stacs 2025",
+    "citation": "Nguyễn, Lê Thành Dũng (Tito), and Gabriele Vanoni. Slightly Non-Linear Higher-Order Tree Transducers. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.68."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.69",
+    "title": "A Dichotomy Theorem for Ordinal Ranks in MSO.",
+    "venue": "stacs 2025",
+    "citation": "Niwiński, Damian, et al. A Dichotomy Theorem for Ordinal Ranks in MSO. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.69."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.70",
+    "title": "Colorful Vertex Recoloring of Bipartite Graphs.",
+    "venue": "stacs 2025",
+    "citation": "Patt-Shamir, Boaz, et al. Colorful Vertex Recoloring of Bipartite Graphs. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.70."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.4",
+    "title": "Some Recent Advancements in Monotone Circuit Complexity (Invited Talk).",
+    "venue": "stacs 2025",
+    "citation": "de Rezende, Susanna F. Some Recent Advancements in Monotone Circuit Complexity (Invited Talk). With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.4."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.71",
+    "title": "Unfairly Splitting Separable Necklaces.",
+    "venue": "stacs 2025",
+    "citation": "Schnider, Patrick, et al. Unfairly Splitting Separable Necklaces. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.71."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.72",
+    "title": "Card-Based Protocols Imply PSM Protocols.",
+    "venue": "stacs 2025",
+    "citation": "Shinagawa, Kazumasa, and Koji Nuida. Card-Based Protocols Imply PSM Protocols. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.72."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.73",
+    "title": "Dominating Set, Independent Set, Discrete k-Center, Dispersion, and Related Problems for Planar Points in Convex Position.",
+    "venue": "stacs 2025",
+    "citation": "Tkachenko, Anastasiia, and Haitao Wang. Dominating Set, Independent Set, Discrete k-Center, Dispersion, and Related Problems for Planar Points in Convex Position. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.73."
+  },
+  {
+    "doi": "10.4230/LIPICS.STACS.2025.74",
+    "title": "Nearly-Optimal Algorithm for Non-Clairvoyant Service with Delay.",
+    "venue": "stacs 2025",
+    "citation": "Touitou, Noam. Nearly-Optimal Algorithm for Non-Clairvoyant Service with Delay. With Olaf Beyersdorff et al., Schloss Dagstuhl – Leibniz-Zentrum für Informatik, 2025, https://doi.org/10.4230/LIPICS.STACS.2025.74."
+  },
+  {
+    "doi": "10.1145/3717823.3718217",
+    "title": "Tight Results for Online Convex Paging.",
+    "venue": "stoc 2025",
+    "citation": "Gupta, Anupam, et al. “Tight Results for Online Convex Paging.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1418–29. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718217."
+  },
+  {
+    "doi": "10.1145/3717823.3718166",
+    "title": "Testing vs Estimation for Index-Invariant Properties in the Huge Object Model.",
+    "venue": "stoc 2025",
+    "citation": "Chakraborty, Sourav, et al. “Testing vs Estimation for Index-Invariant Properties in the Huge Object Model.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1007–18. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718166."
+  },
+  {
+    "doi": "10.1145/3717823.3718146",
+    "title": "Characterizing and Testing Principal Minor Equivalence of Matrices.",
+    "venue": "stoc 2025",
+    "citation": "Chatterjee, Abhranil, et al. “Characterizing and Testing Principal Minor Equivalence of Matrices.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1067–78. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718146."
+  },
+  {
+    "doi": "10.1145/3717823.3718224",
+    "title": "Maximum Circuit Lower Bounds for Exponential-Time Arthur Merlin.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Lijie, et al. “Maximum Circuit Lower Bounds for Exponential-Time Arthur Merlin.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1348–58. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718224."
+  },
+  {
+    "doi": "10.1145/3717823.3718177",
+    "title": "Fiat-Shamir in the Plain Model from Derandomization (Or: Do Efficient Algorithms Believe that NP = PSPACE?).",
+    "venue": "stoc 2025",
+    "citation": "Chen, Lijie, et al. “Fiat-Shamir in the Plain Model from Derandomization (Or: Do Efficient Algorithms Believe That NP = PSPACE?).” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 977–85. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718177."
+  },
+  {
+    "doi": "10.1145/3717823.3718196",
+    "title": "Online Stochastic Matching with Unknown Arrival Order: Beating 0.5 against the Online Optimum.",
+    "venue": "stoc 2025",
+    "citation": "Sun, Enze, et al. “Online Stochastic Matching with Unknown Arrival Order: Beating 0.5 against the Online Optimum.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1430–41. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718196."
+  },
+  {
+    "doi": "10.1145/3717823.3718230",
+    "title": "Phase Transitions via Complex Extensions of Markov Chains.",
+    "venue": "stoc 2025",
+    "citation": "Liu, Jingcheng, et al. “Phase Transitions via Complex Extensions of Markov Chains.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 903–14. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718230."
+  },
+  {
+    "doi": "10.1145/3717823.3718198",
+    "title": "Polynomial-Time PIT from (Almost) Necessary Assumptions.",
+    "venue": "stoc 2025",
+    "citation": "Andrews, Robert, et al. “Polynomial-Time PIT from (Almost) Necessary Assumptions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1087–95. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718198."
+  },
+  {
+    "doi": "10.1145/3717823.3718267",
+    "title": "Accelerated Approximate Optimization of Multi-commodity Flows on Directed Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Li, et al. “Accelerated Approximate Optimization of Multi-Commodity Flows on Directed Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2203–12. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718267."
+  },
+  {
+    "doi": "10.1145/3717823.3718240",
+    "title": "All-Pairs Shortest Paths with Few Weights per Node.",
+    "venue": "stoc 2025",
+    "citation": "Abboud, Amir, et al. “All-Pairs Shortest Paths with Few Weights per Node.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1956–64. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718240."
+  },
+  {
+    "doi": "10.1145/3717823.3718164",
+    "title": "Succinct Oblivious Tensor Evaluation and Applications: Adaptively-Secure Laconic Function Evaluation and Trapdoor Hashing for All Circuits.",
+    "venue": "stoc 2025",
+    "citation": "Abram, Damiano, et al. “Succinct Oblivious Tensor Evaluation and Applications: Adaptively-Secure Laconic Function Evaluation and Trapdoor Hashing for All Circuits.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1875–86. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718164."
+  },
+  {
+    "doi": "10.1145/3717823.3718248",
+    "title": "Pauli Measurements Are Not Optimal for Single-Copy Tomography.",
+    "venue": "stoc 2025",
+    "citation": "Acharya, Jayadev, et al. “Pauli Measurements Are Not Optimal for Single-Copy Tomography.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 718–29. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718248."
+  },
+  {
+    "doi": "10.1145/3717823.3718211",
+    "title": "Online Locality Meets Distributed Quantum Computing.",
+    "venue": "stoc 2025",
+    "citation": "Akbari, Amirreza, et al. “Online Locality Meets Distributed Quantum Computing.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1295–306. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718211."
+  },
+  {
+    "doi": "10.1145/3717823.3718150",
+    "title": "Lifting to Bounded-Depth and Regular Resolutions over Parities via Games.",
+    "venue": "stoc 2025",
+    "citation": "Alekseev, Yaroslav, and Dmitry Itsykson. “Lifting to Bounded-Depth and Regular Resolutions over Parities via Games.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 584–95. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718150."
+  },
+  {
+    "doi": "10.1145/3717823.3718158",
+    "title": "From Signaling to Interviews in Random Matching Markets.",
+    "venue": "stoc 2025",
+    "citation": "Allman, Maxwell, et al. “From Signaling to Interviews in Random Matching Markets.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1556–67. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718158."
+  },
+  {
+    "doi": "10.1145/3717823.3718287",
+    "title": "Low Rank Matrix Rigidity: Tight Lower Bounds and Hardness Amplification.",
+    "venue": "stoc 2025",
+    "citation": "Alman, Josh, and Jingxun Liang. “Low Rank Matrix Rigidity: Tight Lower Bounds and Hardness Amplification.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1383–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718287."
+  },
+  {
+    "doi": "10.1145/3717823.3718262",
+    "title": "DNF Learning via Locally Mixing Random Walks.",
+    "venue": "stoc 2025",
+    "citation": "Alman, Josh, et al. “DNF Learning via Locally Mixing Random Walks.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2055–61. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718262."
+  },
+  {
+    "doi": "10.1145/3717823.3718309",
+    "title": "Ideal Pseudorandom Codes.",
+    "venue": "stoc 2025",
+    "citation": "Alrabiah, Omar, et al. “Ideal Pseudorandom Codes.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1638–47. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718309."
+  },
+  {
+    "doi": "10.1145/3717823.3718317",
+    "title": "Adaptive Approximation Schemes for Matching Queues.",
+    "venue": "stoc 2025",
+    "citation": "AmaniHamedani, Alireza, et al. “Adaptive Approximation Schemes for Matching Queues.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1454–64. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718317."
+  },
+  {
+    "doi": "10.1145/3717823.3718147",
+    "title": "Approximation Algorithms for the Geometric Multimatching Problem.",
+    "venue": "stoc 2025",
+    "citation": "An, Shinwoo, et al. “Approximation Algorithms for the Geometric Multimatching Problem.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2317–28. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718147."
+  },
+  {
+    "doi": "10.1145/3717823.3718250",
+    "title": "Computational Lower Bounds for No-Regret Learning in Normal-Form Games.",
+    "venue": "stoc 2025",
+    "citation": "Anagnostides, Ioannis, et al. “Computational Lower Bounds for No-Regret Learning in Normal-Form Games.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 530–41. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718250."
+  },
+  {
+    "doi": "10.1145/3717823.3718173",
+    "title": "Smoothed Analysis for Graph Isomorphism.",
+    "venue": "stoc 2025",
+    "citation": "Anastos, Michael, et al. “Smoothed Analysis for Graph Isomorphism.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2098–106. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718173."
+  },
+  {
+    "doi": "10.1145/3717823.3718218",
+    "title": "Sample-Optimal Private Regression in Polynomial Time.",
+    "venue": "stoc 2025",
+    "citation": "Anderson, Prashanti, et al. “Sample-Optimal Private Regression in Polynomial Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2341–49. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718218."
+  },
+  {
+    "doi": "10.1145/3717823.3718300",
+    "title": "A Framework for Building Data Structures from Communication Protocols.",
+    "venue": "stoc 2025",
+    "citation": "Andoni, Alexandr, et al. “A Framework for Building Data Structures from Communication Protocols.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 256–67. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718300."
+  },
+  {
+    "doi": "10.1145/3717823.3718189",
+    "title": "On the Computational Power of QAC0 with Barely Superlinear Ancillae.",
+    "venue": "stoc 2025",
+    "citation": "Anshu, Anurag, et al. “On the Computational Power of QAC0 with Barely Superlinear Ancillae.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1476–87. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718189."
+  },
+  {
+    "doi": "10.1145/3717823.3718161",
+    "title": "The Meta-complexity of Secret Sharing.",
+    "venue": "stoc 2025",
+    "citation": "Applebaum, Benny, and Oded Nir. “The Meta-Complexity of Secret Sharing.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 965–76. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718161."
+  },
+  {
+    "doi": "10.1145/3717823.3718277",
+    "title": "Polynomial-Time Tolerant Testing Stabilizer States.",
+    "venue": "stoc 2025",
+    "citation": "Arunachalam, Srinivasan, and Arkopal Dutt. “Polynomial-Time Tolerant Testing Stabilizer States.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1234–41. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718277."
+  },
+  {
+    "doi": "10.1145/3717823.3718289",
+    "title": "Testing and Learning Structured Quantum Hamiltonians.",
+    "venue": "stoc 2025",
+    "citation": "Arunachalam, Srinivasan, et al. “Testing and Learning Structured Quantum Hamiltonians.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1263–70. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718289."
+  },
+  {
+    "doi": "10.1145/3717823.3718265",
+    "title": "Vizing&apos;s Theorem in Near-Linear Time.",
+    "venue": "stoc 2025",
+    "citation": "Assadi, Sepehr, et al. “Vizing’s Theorem in Near-Linear Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 24–35. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718265."
+  },
+  {
+    "doi": "10.1145/3717823.3718298",
+    "title": "Covering Approximate Shortest Paths with DAGs.",
+    "venue": "stoc 2025",
+    "citation": "Assadi, Sepehr, et al. “Covering Approximate Shortest Paths with DAGs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2269–80. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718298."
+  },
+  {
+    "doi": "10.1145/3717823.3718194",
+    "title": "Correlation Clustering and (De)Sparsification: Graph Sketches Can Match Classical Algorithms.",
+    "venue": "stoc 2025",
+    "citation": "Assadi, Sepehr, et al. “Correlation Clustering and (De)Sparsification: Graph Sketches Can Match Classical Algorithms.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 417–28. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718194."
+  },
+  {
+    "doi": "10.1145/3717823.3718276",
+    "title": "Feasibly Constructive Proof of Schwartz-Zippel Lemma and the Complexity of Finding Hitting Sets.",
+    "venue": "stoc 2025",
+    "citation": "Atserias, Albert, and Iddo Tzameret. “Feasibly Constructive Proof of Schwartz–Zippel Lemma and the Complexity of Finding Hitting Sets.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1096–107. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718276."
+  },
+  {
+    "doi": "10.1145/3717823.3718283",
+    "title": "History-Independent Concurrent Hash Tables.",
+    "venue": "stoc 2025",
+    "citation": "Attiya, Hagit, et al. “History-Independent Concurrent Hash Tables.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1283–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718283."
+  },
+  {
+    "doi": "10.1145/3717823.3718154",
+    "title": "Hardness of 4-Colouring k-Colourable Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Avvakumov, Sergey, et al. “Hardness of 4-Colouring 𝐺-Colourable Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 72–83. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718154."
+  },
+  {
+    "doi": "10.1145/3717823.3718279",
+    "title": "Stochastic Matching via In-n-Out Local Computation Algorithms.",
+    "venue": "stoc 2025",
+    "citation": "Azarmehr, Amir, et al. “Stochastic Matching via In-n-Out Local Computation Algorithms.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1055–66. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718279."
+  },
+  {
+    "doi": "10.1145/3717823.3718119",
+    "title": "Share-Based Fairness for Arbitrary Entitlements.",
+    "venue": "stoc 2025",
+    "citation": "Babaioff, Moshe, and Uriel Feige. “Share-Based Fairness for Arbitrary Entitlements.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1544–55. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718119."
+  },
+  {
+    "doi": "10.1145/3717823.3718137",
+    "title": "Rounding Large Independent Sets on Expanders.",
+    "venue": "stoc 2025",
+    "citation": "Bafna, Mitali, et al. “Rounding Large Independent Sets on Expanders.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 631–42. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718137."
+  },
+  {
+    "doi": "10.1145/3717823.3718197",
+    "title": "Quasi-Linear Size PCPs with Small Soundness from HDX.",
+    "venue": "stoc 2025",
+    "citation": "Bafna, Mitali, et al. “Quasi-Linear Size PCPs with Small Soundness from HDX.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 45–53. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718197."
+  },
+  {
+    "doi": "10.1145/3717823.3718170",
+    "title": "Constant Degree Networks for Almost-Everywhere Reliable Transmission.",
+    "venue": "stoc 2025",
+    "citation": "Bafna, Mitali, and Dor Minzer. “Constant Degree Networks for Almost-Everywhere Reliable Transmission.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1319–28. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718170."
+  },
+  {
+    "doi": "10.1145/3717823.3718257",
+    "title": "Near Optimal Constant Inapproximability under ETH for Fundamental Problems in Parameterized Complexity.",
+    "venue": "stoc 2025",
+    "citation": "Bafna, Mitali, et al. “Near Optimal Constant Inapproximability under ETH for Fundamental Problems in Parameterized Complexity.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2118–29. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718257."
+  },
+  {
+    "doi": "10.1145/3717823.3718207",
+    "title": "Learning the Closest Product State.",
+    "venue": "stoc 2025",
+    "citation": "Bakshi, Ainesh, et al. “Learning the Closest Product State.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1212–21. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718207."
+  },
+  {
+    "doi": "10.1145/3717823.3718143",
+    "title": "Extractors for Samplable Distributions with Low Min-Entropy.",
+    "venue": "stoc 2025",
+    "citation": "Ball, Marshall, et al. “Extractors for Samplable Distributions with Low Min-Entropy.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 596–603. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718143."
+  },
+  {
+    "doi": "10.1145/3717823.3718233",
+    "title": "Distributed Quantum Advantage for Local Problems.",
+    "venue": "stoc 2025",
+    "citation": "Balliu, Alkida, et al. “Distributed Quantum Advantage for Local Problems.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 451–62. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718233."
+  },
+  {
+    "doi": "10.1145/3717823.3718188",
+    "title": "Tensor Concentration Inequalities: A Geometric Approach.",
+    "venue": "stoc 2025",
+    "citation": "Bandeira, Afonso S., et al. “Tensor Concentration Inequalities: A Geometric Approach.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 822–32. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718188."
+  },
+  {
+    "doi": "10.1145/3717823.3718238",
+    "title": "Matrix Chaos Inequalities and Chaos of Combinatorial Type.",
+    "venue": "stoc 2025",
+    "citation": "Bandeira, Afonso S., et al. “Matrix Chaos Inequalities and Chaos of Combinatorial Type.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 795–805. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718238."
+  },
+  {
+    "doi": "10.1145/3717823.3718125",
+    "title": "Sandwiching Random Geometric Graphs and Erdos-Renyi with Applications: Sharp Thresholds, Robust Testing, and Enumeration.",
+    "venue": "stoc 2025",
+    "citation": "Bangachev, Kiril, and Guy Bresler. “Sandwiching Random Geometric Graphs and Erdos-Renyi with Applications: Sharp Thresholds, Robust Testing, and Enumeration.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 310–21. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718125."
+  },
+  {
+    "doi": "10.1145/3717823.3718284",
+    "title": "Near-Optimal Time-Sparsity Trade-Offs for Solving Noisy Linear Equations.",
+    "venue": "stoc 2025",
+    "citation": "Bangachev, Kiril, et al. “Near-Optimal Time-Sparsity Trade-Offs for Solving Noisy Linear Equations.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1910–20. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718284."
+  },
+  {
+    "doi": "10.1145/3717823.3718201",
+    "title": "Tolerant Testing of Stabilizer States with a Polynomial Gap via a Generalized Uncertainty Relation.",
+    "venue": "stoc 2025",
+    "citation": "Bao, Zongbo, et al. “Tolerant Testing of Stabilizer States with a Polynomial Gap via a Generalized Uncertainty Relation.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1254–62. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718201."
+  },
+  {
+    "doi": "10.1145/3717823.3718175",
+    "title": "Monotone Contractions.",
+    "venue": "stoc 2025",
+    "citation": "Batziou, Eleni, et al. “Monotone Contractions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 507–17. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718175."
+  },
+  {
+    "doi": "10.1145/3717823.3718215",
+    "title": "Optimal Non-oblivious Open Addressing.",
+    "venue": "stoc 2025",
+    "citation": "Bender, Michael A., et al. “Optimal Non-Oblivious Open Addressing.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 268–77. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718215."
+  },
+  {
+    "doi": "10.1145/3717823.3718152",
+    "title": "Matroid Products via Submodular Coupling.",
+    "venue": "stoc 2025",
+    "citation": "Bérczi, Kristóf, et al. “Matroid Products via Submodular Coupling.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2074–85. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718152."
+  },
+  {
+    "doi": "10.1145/3717823.3718221",
+    "title": "Computing Moment Polytopes of Tensors, with Applications in Algebraic Complexity and Quantum Information.",
+    "venue": "stoc 2025",
+    "citation": "van den Berg, Maxim, et al. “Computing Moment Polytopes of Tensors, with Applications in Algebraic Complexity and Quantum Information.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 756–65. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718221."
+  },
+  {
+    "doi": "10.1145/3717823.3718153",
+    "title": "Deterministic Dynamic Maximal Matching in Sublinear Update Time.",
+    "venue": "stoc 2025",
+    "citation": "Bernstein, Aaron, et al. “Deterministic Dynamic Maximal Matching in Sublinear Update Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 132–43. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718153."
+  },
+  {
+    "doi": "10.1145/3717823.3718190",
+    "title": "Parallel Repetition for 3-Player XOR Games.",
+    "venue": "stoc 2025",
+    "citation": "Bhangale, Amey, et al. “Parallel Repetition for 3-Player 𝘟𝘖𝘙 Games.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 104–10. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718190."
+  },
+  {
+    "doi": "10.1145/3717823.3718127",
+    "title": "On Approximability of Satisfiable k-CSPs: V.",
+    "venue": "stoc 2025",
+    "citation": "Bhangale, Amey, et al. “On Approximability of Satisfiable 𝑘-CSPs: V.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 62–71. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718127."
+  },
+  {
+    "doi": "10.1145/3717823.3718176",
+    "title": "Fully Dynamic k-Median with Near-Optimal Update Time and Recourse.",
+    "venue": "stoc 2025",
+    "citation": "Bhattacharya, Sayan, et al. “Fully Dynamic 𝑘-Median with Near-Optimal Update Time and Recourse.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1166–77. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718176."
+  },
+  {
+    "doi": "10.1145/3717823.3718149",
+    "title": "Reachability in One-Dimensional Pushdown Vector Addition Systems Is Decidable.",
+    "venue": "stoc 2025",
+    "citation": "Bizière, Clotilde, and Wojciech Czerwiński. “Reachability in One-Dimensional Pushdown Vector Addition Systems Is Decidable.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1851–62. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718149."
+  },
+  {
+    "doi": "10.1145/3717823.3718193",
+    "title": "Adaptive and Oblivious Statistical Adversaries Are Equivalent.",
+    "venue": "stoc 2025",
+    "citation": "Blanc, Guy, and Gregory Valiant. “Adaptive and Oblivious Statistical Adversaries Are Equivalent.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2031–42. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718193."
+  },
+  {
+    "doi": "10.1145/3717823.3718111",
+    "title": "Agnostic Smoothed Online Learning.",
+    "venue": "stoc 2025",
+    "citation": "Blanchard, Moïse. “Agnostic Smoothed Online Learning.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1997–2006. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718111."
+  },
+  {
+    "doi": "10.1145/3717823.3718316",
+    "title": "Global vs. s-t Vertex Connectivity Beyond Sequential: Almost-Perfect Reductions and Near-Optimal Separations.",
+    "venue": "stoc 2025",
+    "citation": "Blikstad, Joakim, et al. “Global vs. s-t Vertex Connectivity Beyond Sequential: Almost-Perfect Reductions and Near-Optimal Separations.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2305–16. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718316."
+  },
+  {
+    "doi": "10.1145/3717823.3718249",
+    "title": "Õptimal Fault-Tolerant Labeling for Reachability and Approximate Distances in Directed Planar Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Boneh, Itai, et al. “Õptimal Fault-Tolerant Labeling for Reachability and Approximate Distances in Directed Planar Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2249–56. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718249."
+  },
+  {
+    "doi": "10.1145/3717823.3718117",
+    "title": "Treewidth Inapproximability and Tight ETH Lower Bound.",
+    "venue": "stoc 2025",
+    "citation": "Bonnet, Édouard. “Treewidth Inapproximability and Tight ETH Lower Bound.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2130–35. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718117."
+  },
+  {
+    "doi": "10.1145/3717823.3718275",
+    "title": "A 5/4-Approximation for Two-Edge Connectivity.",
+    "venue": "stoc 2025",
+    "citation": "Bosch-Calvo, Miguel, et al. “A 5/4-Approximation for Two-Edge Connectivity.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 653–64. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718275."
+  },
+  {
+    "doi": "10.1145/3717823.3718195",
+    "title": "A General Quantum Duality for Representations of Groups with Applications to Quantum Money, Lightning, and Fire.",
+    "venue": "stoc 2025",
+    "citation": "Bostanci, John, et al. “A General Quantum Duality for Representations of Groups with Applications to Quantum Money, Lightning, and Fire.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 201–12. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718195."
+  },
+  {
+    "doi": "10.1145/3717823.3718118",
+    "title": "The State Hidden Subgroup Problem and an Efficient Algorithm for Locating Unentanglement.",
+    "venue": "stoc 2025",
+    "citation": "Bouland, Adam, et al. “The State Hidden Subgroup Problem and an Efficient Algorithm for Locating Unentanglement.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 463–70. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718118."
+  },
+  {
+    "doi": "10.1145/3717823.3718320",
+    "title": "Faster Distributed Δ-Coloring via Ruling Subgraphs.",
+    "venue": "stoc 2025",
+    "citation": "Bourreau, Yann, et al. “Faster Distributed Δ-Coloring via Ruling Subgraphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1307–18. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718320."
+  },
+  {
+    "doi": "10.1145/3717823.3718212",
+    "title": "Redundancy Is All You Need.",
+    "venue": "stoc 2025",
+    "citation": "Brakensiek, Joshua, and Venkatesan Guruswami. “Redundancy Is All You Need.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1614–25. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718212."
+  },
+  {
+    "doi": "10.1145/3717823.3718171",
+    "title": "Optimality of Frequency Moment Estimation.",
+    "venue": "stoc 2025",
+    "citation": "Braverman, Mark, and Or Zamir. “Optimality of Frequency Moment Estimation.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 360–70. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718171."
+  },
+  {
+    "doi": "10.1145/3717823.3718141",
+    "title": "A Fine-Grained Classification of Subquadratic Patterns for Subgraph Listing and Friends.",
+    "venue": "stoc 2025",
+    "citation": "Bringmann, Karl, and Egor Gorbachev. “A Fine-Grained Classification of Subquadratic Patterns for Subgraph Listing and Friends.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2145–56. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718141."
+  },
+  {
+    "doi": "10.1145/3717823.3718120",
+    "title": "Extending the Extension: Deterministic Algorithm for Non-monotone Submodular Maximization.",
+    "venue": "stoc 2025",
+    "citation": "Buchbinder, Niv, and Moran Feldman. “Extending the Extension: Deterministic Algorithm for Non-Monotone Submodular Maximization.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1130–41. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718120."
+  },
+  {
+    "doi": "10.1145/3717823.3718181",
+    "title": "Solving the Correlation Cluster LP in Sublinear Time.",
+    "venue": "stoc 2025",
+    "citation": "Cao, Nairen, et al. “Solving the Correlation Cluster LP in Sublinear Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1154–65. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718181."
+  },
+  {
+    "doi": "10.1145/3717823.3718140",
+    "title": "Network Unreliability in Almost-Linear Time.",
+    "venue": "stoc 2025",
+    "citation": "Cen, Ruoxu, et al. “Network Unreliability in Almost-Linear Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 120–31. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718140."
+  },
+  {
+    "doi": "10.1145/3717823.3718314",
+    "title": "Output-Sensitive Approximate Counting via a Measure-Bounded Hyperedge Oracle, or: How Asymmetry Helps Estimate k-Clique Counts Faster.",
+    "venue": "stoc 2025",
+    "citation": "Censor-Hillel, Keren, et al. “Output-Sensitive Approximate Counting via a Measure-Bounded Hyperedge Oracle, or: How Asymmetry Helps Estimate 𝑘-Clique Counts Faster.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1985–96. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718314."
+  },
+  {
+    "doi": "10.1145/3717823.3718319",
+    "title": "Quantum Advantage from Soft Decoders.",
+    "venue": "stoc 2025",
+    "citation": "Chailloux, André, and Jean-Pierre Tillich. “Quantum Advantage from Soft Decoders.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 738–49. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718319."
+  },
+  {
+    "doi": "10.1145/3717823.3718297",
+    "title": "Monotonicity Testing of High-Dimensional Distributions with Subcube Conditioning.",
+    "venue": "stoc 2025",
+    "citation": "Chakrabarty, Deeparnab, et al. “Monotonicity Testing of High-Dimensional Distributions with Subcube Conditioning.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1019–30. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718297."
+  },
+  {
+    "doi": "10.1145/3717823.3718301",
+    "title": "How Random CSPs Fool Hierarchies: II.",
+    "venue": "stoc 2025",
+    "citation": "Chan, Siu On, and Hiu Tsun Ng. “How Random CSPs Fool Hierarchies: II.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1710–21. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718301."
+  },
+  {
+    "doi": "10.1145/3717823.3718232",
+    "title": "Learning the Sherrington-Kirkpatrick Model Even at Low Temperature.",
+    "venue": "stoc 2025",
+    "citation": "Chandrasekaran, Gautam, and Adam R. Klivans. “Learning the Sherrington-Kirkpatrick Model Even at Low Temperature.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1774–84. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718232."
+  },
+  {
+    "doi": "10.1145/3717823.3718312",
+    "title": "Light Tree Covers, Routing, and Path-Reporting Oracles via Spanning Tree Covers in Doubling Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Chang, Hsien-Chih, et al. “Light Tree Covers, Routing, and Path-Reporting Oracles via Spanning Tree Covers in Doubling Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2257–68. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718312."
+  },
+  {
+    "doi": "10.1145/3717823.3718285",
+    "title": "Optimal Rounding for Sparsest Cut.",
+    "venue": "stoc 2025",
+    "citation": "Chang, Alan, et al. “Optimal Rounding for Sparsest Cut.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 643–52. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718285."
+  },
+  {
+    "doi": "10.1145/3717823.3718235",
+    "title": "Six Candidates Suffice to Win a Voter Majority.",
+    "venue": "stoc 2025",
+    "citation": "Charikar, Moses, et al. “Six Candidates Suffice to Win a Voter Majority.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1590–601. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718235."
+  },
+  {
+    "doi": "10.1145/3717823.3718226",
+    "title": "Uncloneable Quantum States Are Necessary as Proofs and Advice.",
+    "venue": "stoc 2025",
+    "citation": "Chatterjee, Rohit, et al. “Uncloneable Quantum States Are Necessary as Proofs and Advice.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1817–27. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718226."
+  },
+  {
+    "doi": "10.1145/3717823.3718272",
+    "title": "Leakage-Resilient Extractors against Number-on-Forehead Protocols.",
+    "venue": "stoc 2025",
+    "citation": "Chattopadhyay, Eshan, and Jesse Goodman. “Leakage-Resilient Extractors against Number-on-Forehead Protocols.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 604–14. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718272."
+  },
+  {
+    "doi": "10.1145/3717823.3718114",
+    "title": "Explicit Folded Reed-Solomon and Multiplicity Codes Achieve Relaxed Generalized Singleton Bounds.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Yeyuan, and Zihan Zhang. “Explicit Folded Reed-Solomon and Multiplicity Codes Achieve Relaxed Generalized Singleton Bounds.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1–12. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718114."
+  },
+  {
+    "doi": "10.1145/3717823.3718281",
+    "title": "Long Arithmetic Progressions in Sumsets and Subset Sums: Constructive Proofs and Efficient Witnesses.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Lin, et al. “Long Arithmetic Progressions in Sumsets and Subset Sums: Constructive Proofs and Efficient Witnesses.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2086–97. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718281."
+  },
+  {
+    "doi": "10.1145/3717823.3718260",
+    "title": "Rapid Mixing at the Uniqueness Threshold.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Xiaoyu, et al. “Rapid Mixing at the Uniqueness Threshold.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 879–90. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718260."
+  },
+  {
+    "doi": "10.1145/3717823.3718159",
+    "title": "Unambiguous SNARGs for P from LWE with Applications to PPAD Hardness.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Liyan, et al. “Unambiguous SNARGs for P from LWE with Applications to PPAD Hardness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 944–54. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718159."
+  },
+  {
+    "doi": "10.1145/3717823.3718191",
+    "title": "Stabilizer Bootstrapping: A Recipe for Efficient Agnostic Tomography and Magic Estimation.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Sitan, et al. “Stabilizer Bootstrapping: A Recipe for Efficient Agnostic Tomography and Magic Estimation.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 429–38. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718191."
+  },
+  {
+    "doi": "10.1145/3717823.3718172",
+    "title": "Succinct Non-interactive Arguments of Proximity.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Liyan, et al. “Succinct Non-Interactive Arguments of Proximity.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 955–64. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718172."
+  },
+  {
+    "doi": "10.1145/3717823.3718174",
+    "title": "Provably Learning a Multi-head Attention Layer.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Sitan, and Yuanzhi Li. “Provably Learning a Multi-Head Attention Layer.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1744–54. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718174."
+  },
+  {
+    "doi": "10.1145/3717823.3718163",
+    "title": "Counting Random k-SAT near the Satisfiability Threshold.",
+    "venue": "stoc 2025",
+    "citation": "Chen, Zongchen, et al. “Counting Random 𝑘-SAT near the Satisfiability Threshold.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 867–78. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718163."
+  },
+  {
+    "doi": "10.1145/3717823.3718157",
+    "title": "Constant Approximation of Fréchet Distance in Strongly Subquadratic Time.",
+    "venue": "stoc 2025",
+    "citation": "Cheng, Siu-Wing, et al. “Constant Approximation of Fréchet Distance in Strongly Subquadratic Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2329–40. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718157."
+  },
+  {
+    "doi": "10.1145/3717823.3718213",
+    "title": "On Reductions and Representations of Learning Problems in Euclidean Spaces.",
+    "venue": "stoc 2025",
+    "citation": "Chornomaz, Bogdan, et al. “On Reductions and Representations of Learning Problems in Euclidean Spaces.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2043–54. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718213."
+  },
+  {
+    "doi": "10.1145/3717823.3718122",
+    "title": "Asymptotic Tensor Rank Is Characterized by Polynomials.",
+    "venue": "stoc 2025",
+    "citation": "Christandl, Matthias, et al. “Asymptotic Tensor Rank Is Characterized by Polynomials.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 750–55. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718122."
+  },
+  {
+    "doi": "10.1145/3717823.3718185",
+    "title": "Breaking the O(m2n)-Time Barrier for Vertex-Weighted Global Minimum Cut.",
+    "venue": "stoc 2025",
+    "citation": "Chuzhoy, Julia, and Ohad Trabelsi. “Breaking the 𝑂(𝑚𝑛)-Time Barrier for Vertex-Weighted Global Minimum Cut.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 144–55. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718185."
+  },
+  {
+    "doi": "10.1145/3717823.3718299",
+    "title": "A (2+ε)-Approximation Algorithm for Metric k-Median.",
+    "venue": "stoc 2025",
+    "citation": "Cohen-Addad, Vincent, et al. “A (2+ε)-Approximation Algorithm for Metric 𝑘-Median.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 615–24. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718299."
+  },
+  {
+    "doi": "10.1145/3717823.3718180",
+    "title": "Almost Optimal PAC Learning for k-Means.",
+    "venue": "stoc 2025",
+    "citation": "Cohen-Addad, Vincent, et al. “Almost Optimal PAC Learning for 𝑘-Means.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2019–30. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718180."
+  },
+  {
+    "doi": "10.1145/3717823.3718222",
+    "title": "Tractable Agreement Protocols.",
+    "venue": "stoc 2025",
+    "citation": "Collina, Natalie, et al. “Tractable Agreement Protocols.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1532–43. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718222."
+  },
+  {
+    "doi": "10.1145/3717823.3718252",
+    "title": "How to Protect Yourself from Threatening Skeletons: Optimal Padded Decompositions for Minor-Free Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Conroy, Jonathan, and Arnold Filtser. “How to Protect Yourself from Threatening Skeletons: Optimal Padded Decompositions for Minor-Free Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2281–92. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718252."
+  },
+  {
+    "doi": "10.1145/3717823.3718112",
+    "title": "The Structure of Catalytic Space: Capturing Randomness and Time via Compression.",
+    "venue": "stoc 2025",
+    "citation": "Cook, James, et al. “The Structure of Catalytic Space: Capturing Randomness and Time via Compression.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 554–64. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718112."
+  },
+  {
+    "doi": "10.1145/3717823.3718132",
+    "title": "Time and Space Efficient Deterministic Decoders.",
+    "venue": "stoc 2025",
+    "citation": "Cook, Joshua, and Dana Moshkovitz. “Time and Space Efficient Deterministic Decoders.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1602–13. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718132."
+  },
+  {
+    "doi": "10.1145/3717823.3718178",
+    "title": "Breaking the T(2/3) Barrier for Sequential Calibration.",
+    "venue": "stoc 2025",
+    "citation": "Dagan, Yuval, et al. “Breaking the T^(2/3) Barrier for Sequential Calibration.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2007–18. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718178."
+  },
+  {
+    "doi": "10.1145/3717823.3718113",
+    "title": "Locality vs Quantum Codes.",
+    "venue": "stoc 2025",
+    "citation": "Dai, Samuel, and Ray Li. “Locality vs Quantum Codes.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 677–88. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718113."
+  },
+  {
+    "doi": "10.1145/3717823.3718307",
+    "title": "Efficient Learning and Computation of Linear Correlated Equilibrium in General Convex Games.",
+    "venue": "stoc 2025",
+    "citation": "Daskalakis, Constantinos, et al. “Efficient Learning and Computation of Linear Correlated Equilibrium in General Convex Games.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 542–53. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718307."
+  },
+  {
+    "doi": "10.1145/3717823.3718103",
+    "title": "On the Locality of the Lovász Local Lemma.",
+    "venue": "stoc 2025",
+    "citation": "Davies-Peck, Peter. “On the Locality of the Lovász Local Lemma.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1271–82. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718103."
+  },
+  {
+    "doi": "10.1145/3717823.3718183",
+    "title": "SoS Certifiability of Subgaussian Distributions and Its Algorithmic Applications.",
+    "venue": "stoc 2025",
+    "citation": "Diakonikolas, Ilias, et al. “SoS Certifiability of Subgaussian Distributions and Its Algorithmic Applications.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1689–700. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718183."
+  },
+  {
+    "doi": "10.1145/3717823.3718293",
+    "title": "SoS Certificates for Sparse Singular Values and Their Applications: Robust Statistics, Subspace Distortion, and More.",
+    "venue": "stoc 2025",
+    "citation": "Diakonikolas, Ilias, et al. “SoS Certificates for Sparse Singular Values and Their Applications: Robust Statistics, Subspace Distortion, and More.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1701–09. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718293."
+  },
+  {
+    "doi": "10.1145/3717823.3718162",
+    "title": "Entangled Mean Estimation in High Dimensions.",
+    "venue": "stoc 2025",
+    "citation": "Diakonikolas, Ilias, et al. “Entangled Mean Estimation in High Dimensions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1680–88. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718162."
+  },
+  {
+    "doi": "10.1145/3717823.3718210",
+    "title": "A New Approach for LPN-Based Pseudorandom Functions: Low-Depth and Key-Homomorphic.",
+    "venue": "stoc 2025",
+    "citation": "Ding, Youlong, et al. “A New Approach for LPN-Based Pseudorandom Functions: Low-Depth and Key-Homomorphic.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1898–909. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718210."
+  },
+  {
+    "doi": "10.1145/3717823.3718303",
+    "title": "When Connectivity Is Hard, Random Walks Are Easy with Non-determinism.",
+    "venue": "stoc 2025",
+    "citation": "Doron, Dean, et al. “When Connectivity Is Hard, Random Walks Are Easy with Non-Determinism.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1108–17. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718303."
+  },
+  {
+    "doi": "10.1145/3717823.3718184",
+    "title": "Disjoint Connected Dominating Sets in Pseudorandom Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Draganić, Nemanja, and Michael Krivelevich. “Disjoint Connected Dominating Sets in Pseudorandom Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 329–35. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718184."
+  },
+  {
+    "doi": "10.1145/3717823.3718259",
+    "title": "Merge-Width and First-Order Model Checking.",
+    "venue": "stoc 2025",
+    "citation": "Dreier, Jan, and Szymon Toruńczyk. “Merge-Width and First-Order Model Checking.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1944–55. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718259."
+  },
+  {
+    "doi": "10.1145/3717823.3718179",
+    "title": "Breaking the Sorting Barrier for Directed Single-Source Shortest Paths.",
+    "venue": "stoc 2025",
+    "citation": "Duan, Ran, et al. “Breaking the Sorting Barrier for Directed Single-Source Shortest Paths.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 36–44. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718179."
+  },
+  {
+    "doi": "10.1145/3717823.3718131",
+    "title": "The Cost of Consistency: Submodular Maximization with Constant Recourse.",
+    "venue": "stoc 2025",
+    "citation": "Dütting, Paul, et al. “The Cost of Consistency: Submodular Maximization with Constant Recourse.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1406–17. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718131."
+  },
+  {
+    "doi": "10.1145/3717823.3718107",
+    "title": "On Approximability of the Permanent of PSD Matrices.",
+    "venue": "stoc 2025",
+    "citation": "Ebrahimnejad, Farzam, et al. “On Approximability of the Permanent of PSD Matrices.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 625–30. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718107."
+  },
+  {
+    "doi": "10.1145/3717823.3718160",
+    "title": "Approximately Counting and Sampling Hamiltonian Motifs in Sublinear Time.",
+    "venue": "stoc 2025",
+    "citation": "Eden, Talya, et al. “Approximately Counting and Sampling Hamiltonian Motifs in Sublinear Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1043–54. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718160."
+  },
+  {
+    "doi": "10.1145/3717823.3718182",
+    "title": "Optimal Proof Systems for Complex Sets Are Hard to Find.",
+    "venue": "stoc 2025",
+    "citation": "Egidy, Fabian, and Christian Glaßer. “Optimal Proof Systems for Complex Sets Are Hard to Find.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1329–40. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718182."
+  },
+  {
+    "doi": "10.1145/3717823.3718126",
+    "title": "Multi-parameter Mechanisms for Consumer Surplus Maximization.",
+    "venue": "stoc 2025",
+    "citation": "Ezra, Tomer, et al. “Multi-Parameter Mechanisms for Consumer Surplus Maximization.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 483–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718126."
+  },
+  {
+    "doi": "10.1145/3717823.3718129",
+    "title": "Constant-Cost Communication Is Not Reducible to k-Hamming Distance.",
+    "venue": "stoc 2025",
+    "citation": "Fang, Yuting, et al. “Constant-Cost Communication Is Not Reducible to k-Hamming Distance.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 565–71. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718129."
+  },
+  {
+    "doi": "10.1145/3717823.3718203",
+    "title": "Constant Approximation for Weighted Nash Social Welfare with Submodular Valuations.",
+    "venue": "stoc 2025",
+    "citation": "Feng, Yuda, et al. “Constant Approximation for Weighted Nash Social Welfare with Submodular Valuations.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1395–405. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718203."
+  },
+  {
+    "doi": "10.1145/3717823.3718261",
+    "title": "Minimum Degree Edge-Disjoint Hamilton Cycles in Random Directed Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Ferber, Asaf, and Adva Mond. “Minimum Degree Edge-Disjoint Hamilton Cycles in Random Directed Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 336–47. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718261."
+  },
+  {
+    "doi": "10.1145/3717823.3718231",
+    "title": "Bypassing the Noisy Parity Barrier: Learning Higher-Order Markov Random Fields from Dynamics.",
+    "venue": "stoc 2025",
+    "citation": "Gaitonde, Jason, et al. “Bypassing the Noisy Parity Barrier: Learning Higher-Order Markov Random Fields from Dynamics.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 348–59. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718231."
+  },
+  {
+    "doi": "10.1145/3717823.3718167",
+    "title": "Primes via Zeros: Interactive Proofs for Testing Primality of Natural Classes of Ideals.",
+    "venue": "stoc 2025",
+    "citation": "Garg, Abhibhav, et al. “Primes via Zeros: Interactive Proofs for Testing Primality of Natural Classes of Ideals.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1079–86. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718167."
+  },
+  {
+    "doi": "10.1145/3717823.3718305",
+    "title": "Constant-Factor EFX Exists for Chores.",
+    "venue": "stoc 2025",
+    "citation": "Garg, Jugal, et al. “Constant-Factor EFX Exists for Chores.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1580–89. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718305."
+  },
+  {
+    "doi": "10.1145/3717823.3718313",
+    "title": "Improved PIR Schemes using Matching Vectors and Derivatives.",
+    "venue": "stoc 2025",
+    "citation": "Ghasemi, Fatemeh, et al. “Improved PIR Schemes Using Matching Vectors and Derivatives.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1648–56. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718313."
+  },
+  {
+    "doi": "10.1145/3717823.3718306",
+    "title": "Using the Planted Clique Conjecture for Cryptography: Public-Key Encryption from Planted Clique and Noisy k-LIN over Expanders.",
+    "venue": "stoc 2025",
+    "citation": "Ghosal, Riddhi, et al. “Using the Planted Clique Conjecture for Cryptography: Public-Key Encryption from Planted Clique and Noisy 𝑘-LIN over Expanders.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1921–32. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718306."
+  },
+  {
+    "doi": "10.1145/3717823.3718246",
+    "title": "Single-Sample and Robust Online Resource Allocation.",
+    "venue": "stoc 2025",
+    "citation": "Ghuge, Rohan, et al. “Single-Sample and Robust Online Resource Allocation.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1442–53. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718246."
+  },
+  {
+    "doi": "10.1145/3717823.3718121",
+    "title": "Metric Distortion of Small-Group Deliberation.",
+    "venue": "stoc 2025",
+    "citation": "Goel, Ashish, et al. “Metric Distortion of Small-Group Deliberation.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1568–79. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718121."
+  },
+  {
+    "doi": "10.1145/3717823.3718245",
+    "title": "Oblivious Defense in ML Models: Backdoor Removal without Detection.",
+    "venue": "stoc 2025",
+    "citation": "Goldwasser, Shafi, et al. “Oblivious Defense in ML Models: Backdoor Removal without Detection.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1785–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718245."
+  },
+  {
+    "doi": "10.1145/3717823.3718234",
+    "title": "Asymptotically Good Quantum Codes with Transversal Non-Clifford Gates.",
+    "venue": "stoc 2025",
+    "citation": "Golowich, Louis, and Venkatesan Guruswami. “Asymptotically Good Quantum Codes with Transversal Non-Clifford Gates.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 707–17. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718234."
+  },
+  {
+    "doi": "10.1145/3717823.3718139",
+    "title": "Quantum LDPC Codes with Transversal Non-Clifford Gates via Products of Algebraic Codes.",
+    "venue": "stoc 2025",
+    "citation": "Golowich, Louis, and Ting-Chun Lin. “Quantum LDPC Codes with Transversal Non-Clifford Gates via Products of Algebraic Codes.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 689–96. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718139."
+  },
+  {
+    "doi": "10.1145/3717823.3718155",
+    "title": "Quantum Communication Advantage in TFNP.",
+    "venue": "stoc 2025",
+    "citation": "Göös, Mika, et al. “Quantum Communication Advantage in TFNP.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1465–75. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718155."
+  },
+  {
+    "doi": "10.1145/3717823.3718229",
+    "title": "Supercritical Tradeoffs for Monotone Circuits.",
+    "venue": "stoc 2025",
+    "citation": "Göös, Mika, et al. “Supercritical Tradeoffs for Monotone Circuits.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1359–70. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718229."
+  },
+  {
+    "doi": "10.1145/3717823.3718168",
+    "title": "Bounded Edit Distance: Optimal Static and Dynamic Algorithms for Small Integer Weights.",
+    "venue": "stoc 2025",
+    "citation": "Gorbachev, Egor, and Tomasz Kociumaka. “Bounded Edit Distance: Optimal Static and Dynamic Algorithms for Small Integer Weights.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2157–66. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718168."
+  },
+  {
+    "doi": "10.1145/3717823.3718156",
+    "title": "Approximation Guarantees of Median Mechanism in ℝᵈ.",
+    "venue": "stoc 2025",
+    "citation": "Gravin, Nikolai, and Jianhao Jia. “Approximation Guarantees of Median Mechanism in ℝᵈ.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 495–506. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718156."
+  },
+  {
+    "doi": "10.1145/3717823.3718227",
+    "title": "Lifting Linear Sketches: Optimal Bounds and Adversarial Robustness.",
+    "venue": "stoc 2025",
+    "citation": "Gribelyuk, Elena, et al. “Lifting Linear Sketches: Optimal Bounds and Adversarial Robustness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 395–406. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718227."
+  },
+  {
+    "doi": "10.1145/3717823.3718282",
+    "title": "On the Complexity of Isomorphism Problems for Tensors, Groups, and Polynomials IV: Linear-Length Reductions and Their Applications.",
+    "venue": "stoc 2025",
+    "citation": "Grochow, Joshua A., and Youming Qiao. “On the Complexity of Isomorphism Problems for Tensors, Groups, and Polynomials IV: Linear-Length Reductions and Their Applications.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 766–76. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718282."
+  },
+  {
+    "doi": "10.1145/3717823.3718286",
+    "title": "On the Complexity of Isomorphism Problems for Tensors, Groups, and Polynomials V: Over Commutative Rings.",
+    "venue": "stoc 2025",
+    "citation": "Grochow, Joshua A., et al. “On the Complexity of Isomorphism Problems for Tensors, Groups, and Polynomials V: Over Commutative Rings.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 777–84. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718286."
+  },
+  {
+    "doi": "10.1145/3717823.3718216",
+    "title": "Student-Teacher Constructive Separations and (Un)Provability in Bounded Arithmetic: Witnessing the Gap.",
+    "venue": "stoc 2025",
+    "citation": "Grosser, Stefan, and Marco Carmosino. “Student-Teacher Constructive Separations and (Un)Provability in Bounded Arithmetic: Witnessing the Gap.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1341–47. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718216."
+  },
+  {
+    "doi": "10.1145/3717823.3718264",
+    "title": "Classical Commitments to Quantum States.",
+    "venue": "stoc 2025",
+    "citation": "Gunn, Sam, et al. “Classical Commitments to Quantum States.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 234–44. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718264."
+  },
+  {
+    "doi": "10.1145/3717823.3718204",
+    "title": "Quantum One-Time Programs, Revisited.",
+    "venue": "stoc 2025",
+    "citation": "Gupte, Aparna, et al. “Quantum One-Time Programs, Revisited.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 213–21. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718204."
+  },
+  {
+    "doi": "10.1145/3717823.3718128",
+    "title": "A Zero-Knowledge PCP Theorem.",
+    "venue": "stoc 2025",
+    "citation": "Gur, Tom, et al. “A Zero-Knowledge PCP Theorem.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 986–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718128."
+  },
+  {
+    "doi": "10.1145/3717823.3718130",
+    "title": "Almost Optimal Time Lower Bound for Approximating Parameterized Clique, CSP, and More, under ETH.",
+    "venue": "stoc 2025",
+    "citation": "Guruswami, Venkatesan, et al. “Almost Optimal Time Lower Bound for Approximating Parameterized Clique, CSP, and More, under ETH.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2136–44. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718130."
+  },
+  {
+    "doi": "10.1145/3717823.3718169",
+    "title": "Single-Copy Stabilizer Testing.",
+    "venue": "stoc 2025",
+    "citation": "Hinsche, Marcel, and Jonas Helsen. “Single-Copy Stabilizer Testing.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 439–50. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718169."
+  },
+  {
+    "doi": "10.1145/3717823.3718244",
+    "title": "Error-Correction of Matrix Multiplication Algorithms.",
+    "venue": "stoc 2025",
+    "citation": "Hirahara, Shuichi, and Nobutaka Shimizu. “Error-Correction of Matrix Multiplication Algorithms.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 785–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718244."
+  },
+  {
+    "doi": "10.1145/3717823.3718270",
+    "title": "Fully Dynamic Biconnectivity in Õ(log² n) Time.",
+    "venue": "stoc 2025",
+    "citation": "Holm, Jacob, et al. “Fully Dynamic Biconnectivity in Õ(Log² n) Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 156–65. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718270."
+  },
+  {
+    "doi": "10.1145/3717823.3718187",
+    "title": "Hypercontractivity on HDX II: Symmetrization and q-Norms.",
+    "venue": "stoc 2025",
+    "citation": "Hopkins, Max. “Hypercontractivity on HDX II: Symmetrization and 𝑞-Norms.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 96–103. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718187."
+  },
+  {
+    "doi": "10.1145/3717823.3718241",
+    "title": "Explicit Two-Sided Vertex Expanders beyond the Spectral Barrier.",
+    "venue": "stoc 2025",
+    "citation": "Hsieh, Jun-Ting, et al. “Explicit Two-Sided Vertex Expanders beyond the Spectral Barrier.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 833–42. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718241."
+  },
+  {
+    "doi": "10.1145/3717823.3718278",
+    "title": "Optimal Static Dictionary with Worst-Case Constant Query Time.",
+    "venue": "stoc 2025",
+    "citation": "Hu, Yang, et al. “Optimal Static Dictionary with Worst-Case Constant Query Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 278–89. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718278."
+  },
+  {
+    "doi": "10.1145/3717823.3718223",
+    "title": "Omnipredicting Single-Index Models with Multi-index Models.",
+    "venue": "stoc 2025",
+    "citation": "Hu, Lunjia, et al. “Omnipredicting Single-Index Models with Multi-Index Models.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1762–73. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718223."
+  },
+  {
+    "doi": "10.1145/3717823.3718214",
+    "title": "Near-Optimal Dimension Reduction for Facility Location.",
+    "venue": "stoc 2025",
+    "citation": "Huang, Lingxiao, et al. “Near-Optimal Dimension Reduction for Facility Location.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 665–76. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718214."
+  },
+  {
+    "doi": "10.1145/3717823.3718236",
+    "title": "Weak Poincaré Inequalities, Simulated Annealing, and Sampling from Spherical Spin Glasses.",
+    "venue": "stoc 2025",
+    "citation": "Huang, Brice, et al. “Weak Poincaré Inequalities, Simulated Annealing, and Sampling from Spherical Spin Glasses.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 915–23. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718236."
+  },
+  {
+    "doi": "10.1145/3717823.3718199",
+    "title": "Simple and Optimal Algorithms for Heavy Hitters and Frequency Moments in Distributed Models.",
+    "venue": "stoc 2025",
+    "citation": "Huang, Zengfeng, et al. “Simple and Optimal Algorithms for Heavy Hitters and Frequency Moments in Distributed Models.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 371–82. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718199."
+  },
+  {
+    "doi": "10.1145/3717823.3718200",
+    "title": "Protecting Computations against Continuous Bounded-Communication Leakage.",
+    "venue": "stoc 2025",
+    "citation": "Ishai, Yuval, and Yifan Song. “Protecting Computations against Continuous Bounded-Communication Leakage.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1887–97. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718200."
+  },
+  {
+    "doi": "10.1145/3717823.3718165",
+    "title": "Fast, Robust Approximate Message Passing.",
+    "venue": "stoc 2025",
+    "citation": "Ivkov, Misha, and Tselil Schramm. “Fast, Robust Approximate Message Passing.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2237–48. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718165."
+  },
+  {
+    "doi": "10.1145/3717823.3718208",
+    "title": "Linear Hashing Is Optimal.",
+    "venue": "stoc 2025",
+    "citation": "Jaber, Michael, et al. “Linear Hashing Is Optimal.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 245–55. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718208."
+  },
+  {
+    "doi": "10.1145/3717823.3718302",
+    "title": "Explicit Codes Approaching Generalized Singleton Bound using Expanders.",
+    "venue": "stoc 2025",
+    "citation": "Jeronimo, Fernando Granha, et al. “Explicit Codes Approaching Generalized Singleton Bound Using Expanders.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 843–54. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718302."
+  },
+  {
+    "doi": "10.1145/3717823.3718105",
+    "title": "Positive Bias Makes Tensor-Network Contraction Tractable.",
+    "venue": "stoc 2025",
+    "citation": "Jiang, Jiaqing, et al. “Positive Bias Makes Tensor-Network Contraction Tractable.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 471–82. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718105."
+  },
+  {
+    "doi": "10.1145/3717823.3718308",
+    "title": "Improved Complexity for Smooth Nonconvex Optimization: A Two-Level Online Learning Approach with Quasi-Newton Methods.",
+    "venue": "stoc 2025",
+    "citation": "Jiang, Ruichen, et al. “Improved Complexity for Smooth Nonconvex Optimization: A Two-Level Online Learning Approach with Quasi-Newton Methods.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2225–36. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718308."
+  },
+  {
+    "doi": "10.1145/3717823.3718304",
+    "title": "Deterministic Vertex Connectivity via Common-Neighborhood Clustering and Pseudorandomness.",
+    "venue": "stoc 2025",
+    "citation": "Jiang, Yonggang, et al. “Deterministic Vertex Connectivity via Common-Neighborhood Clustering and Pseudorandomness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2293–304. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718304."
+  },
+  {
+    "doi": "10.1145/3717823.3718104",
+    "title": "Universal SNARGs for NP from Proofs of Correctness.",
+    "venue": "stoc 2025",
+    "citation": "Jin, Zhengzhong, et al. “Universal SNARGs for NP from Proofs of Correctness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 933–43. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718104."
+  },
+  {
+    "doi": "10.1145/3717823.3718110",
+    "title": "The Hypergraph Removal Process.",
+    "venue": "stoc 2025",
+    "citation": "Joos, Felix, and Marcus Kühn. “The Hypergraph Removal Process.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 301–09. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718110."
+  },
+  {
+    "doi": "10.1145/3717823.3718273",
+    "title": "The Jacobi Factoring Circuit: Quantum Factoring with Near-Linear Gates and Sublinear Space and Depth.",
+    "venue": "stoc 2025",
+    "citation": "Kahanamoku-Meyer, Gregory D., et al. “The Jacobi Factoring Circuit: Quantum Factoring with Near-Linear Gates and Sublinear Space and Depth.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1496–507. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718273."
+  },
+  {
+    "doi": "10.1145/3717823.3718108",
+    "title": "On the Limits of Language Generation: Trade-Offs between Hallucination and Mode-Collapse.",
+    "venue": "stoc 2025",
+    "citation": "Kalavasis, Alkis, et al. “On the Limits of Language Generation: Trade-Offs between Hallucination and Mode-Collapse.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1732–43. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718108."
+  },
+  {
+    "doi": "10.1145/3717823.3718243",
+    "title": "Locally Sampleable Uniform Symmetric Distributions.",
+    "venue": "stoc 2025",
+    "citation": "Kane, Daniel M., et al. “Locally Sampleable Uniform Symmetric Distributions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1807–16. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718243."
+  },
+  {
+    "doi": "10.1145/3717823.3718274",
+    "title": "On Differentially Private Linear Algebra.",
+    "venue": "stoc 2025",
+    "citation": "Kaplan, Haim, et al. “On Differentially Private Linear Algebra.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2362–73. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718274."
+  },
+  {
+    "doi": "10.1145/3717823.3718136",
+    "title": "Coboundary Expansion of Coset Complexes.",
+    "venue": "stoc 2025",
+    "citation": "Kaufman, Tali, et al. “Coboundary Expansion of Coset Complexes.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1722–31. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718136."
+  },
+  {
+    "doi": "10.1145/3717823.3718291",
+    "title": "On the Hardness Hierarchy for the O(n√log n) Complexity in the Word RAM.",
+    "venue": "stoc 2025",
+    "citation": "Kempa, Dominik, and Tomasz Kociumaka. “On the Hardness Hierarchy for the 𝑂(𝑛 √log 𝑛) Complexity in the Word RAM.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 290–300. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718291."
+  },
+  {
+    "doi": "10.1145/3717823.3718239",
+    "title": "Near-Optimal Linear Sketches and Fully-Dynamic Algorithms for Hypergraph Spectral Sparsification.",
+    "venue": "stoc 2025",
+    "citation": "Khanna, Sanjeev, et al. “Near-Optimal Linear Sketches and Fully-Dynamic Algorithms for Hypergraph Spectral Sparsification.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1190–200. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718239."
+  },
+  {
+    "doi": "10.1145/3717823.3718205",
+    "title": "Efficient Algorithms and New Characterizations for CSP Sparsification.",
+    "venue": "stoc 2025",
+    "citation": "Khanna, Sanjeev, et al. “Efficient Algorithms and New Characterizations for CSP Sparsification.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 407–16. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718205."
+  },
+  {
+    "doi": "10.1145/3717823.3718145",
+    "title": "Founding Quantum Cryptography on Quantum Advantage, or, Towards Cryptography from #P Hardness.",
+    "venue": "stoc 2025",
+    "citation": "Khurana, Dakshita, and Kabir Tomer. “Founding Quantum Cryptography on Quantum Advantage, or, Towards Cryptography from #P Hardness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 178–88. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718145."
+  },
+  {
+    "doi": "10.1145/3717823.3718138",
+    "title": "Faster Lattice Basis Computation via a Natural Generalization of the Euclidean Algorithm.",
+    "venue": "stoc 2025",
+    "citation": "Klein, Kim-Manuel, and Janina Reuter. “Faster Lattice Basis Computation via a Natural Generalization of the Euclidean Algorithm.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2179–90. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718138."
+  },
+  {
+    "doi": "10.1145/3717823.3718288",
+    "title": "Approximating the Held-Karp Bound for Metric TSP in Nearly Linear Work and Polylogarithmic Depth.",
+    "venue": "stoc 2025",
+    "citation": "Koh, Zhuan Khye, et al. “Approximating the Held–Karp Bound for Metric TSP in Nearly Linear Work and Polylogarithmic Depth.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 166–77. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718288."
+  },
+  {
+    "doi": "10.1145/3717823.3718202",
+    "title": "Sampling and Integration of Logconcave Functions by Algorithmic Diffusion.",
+    "venue": "stoc 2025",
+    "citation": "Kook, Yunbum, and Santosh S. Vempala. “Sampling and Integration of Logconcave Functions by Algorithmic Diffusion.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 924–32. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718202."
+  },
+  {
+    "doi": "10.1145/3717823.3718106",
+    "title": "High Rate Multivariate Polynomial Evaluation Codes.",
+    "venue": "stoc 2025",
+    "citation": "Kopparty, Swastik, et al. “High Rate Multivariate Polynomial Evaluation Codes.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 810–21. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718106."
+  },
+  {
+    "doi": "10.1145/3717823.3718123",
+    "title": "Linear-Time Algorithms for k-Edge-Connected Components, k-Lean Tree Decompositions, and More.",
+    "venue": "stoc 2025",
+    "citation": "Korhonen, Tuukka. “Linear-Time Algorithms for k-Edge-Connected Components, k-Lean Tree Decompositions, and More.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 111–19. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718123."
+  },
+  {
+    "doi": "10.1145/3717823.3718144",
+    "title": "Quantum-Computable One-Way Functions without One-Way Functions.",
+    "venue": "stoc 2025",
+    "citation": "Kretschmer, William, et al. “Quantum-Computable One-Way Functions without One-Way Functions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 189–200. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718144."
+  },
+  {
+    "doi": "10.1145/3717823.3718237",
+    "title": "A Bound on the Quantum Value of All Compiled Nonlocal Games.",
+    "venue": "stoc 2025",
+    "citation": "Kulpe, Alexander, et al. “A Bound on the Quantum Value of All Compiled Nonlocal Games.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 222–33. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718237."
+  },
+  {
+    "doi": "10.1145/3717823.3718280",
+    "title": "Statistical Inference of a Ranked Community in a Directed Graph.",
+    "venue": "stoc 2025",
+    "citation": "Kunisky, Dmitriy, et al. “Statistical Inference of a Ranked Community in a Directed Graph.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2107–17. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718280."
+  },
+  {
+    "doi": "10.1145/3717823.3718209",
+    "title": "Dynamic Locality Sensitive Orderings in Doubling Metrics.",
+    "venue": "stoc 2025",
+    "citation": "La, An, and Hung Le. “Dynamic Locality Sensitive Orderings in Doubling Metrics.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1178–89. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718209."
+  },
+  {
+    "doi": "10.1145/3717823.3718311",
+    "title": "Learning Quantum States Prepared by Shallow Circuits in Polynomial Time.",
+    "venue": "stoc 2025",
+    "citation": "Landau, Zeph, and Yunchao Liu. “Learning Quantum States Prepared by Shallow Circuits in Polynomial Time.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1828–38. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718311."
+  },
+  {
+    "doi": "10.1145/3717823.3718142",
+    "title": "Asymptotically Optimal Hardness for k-Set Packing and k-Matroid Intersection.",
+    "venue": "stoc 2025",
+    "citation": "Lee, Euiwoong, et al. “Asymptotically Optimal Hardness for 𝑘-Set Packing and 𝑘-Matroid Intersection.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 54–61. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718142."
+  },
+  {
+    "doi": "10.1145/3717823.3718310",
+    "title": "The 2-Token Theorem: Recognising History-Deterministic Parity Automata Efficiently.",
+    "venue": "stoc 2025",
+    "citation": "Lehtinen, Karoliina, and Aditya Prakash. “The 2-Token Theorem: Recognising History-Deterministic Parity Automata Efficiently.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1839–50. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718310."
+  },
+  {
+    "doi": "10.1145/3717823.3718124",
+    "title": "Discrepancy Algorithms for the Binary Perceptron.",
+    "venue": "stoc 2025",
+    "citation": "Li, Shuangping, et al. “Discrepancy Algorithms for the Binary Perceptron.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1668–79. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718124."
+  },
+  {
+    "doi": "10.1145/3717823.3718247",
+    "title": "Privately Evaluating Untrusted Black-Box Functions.",
+    "venue": "stoc 2025",
+    "citation": "Linder, Ephraim, et al. “Privately Evaluating Untrusted Black-Box Functions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2350–61. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718247."
+  },
+  {
+    "doi": "10.1145/3717823.3718220",
+    "title": "Model Stealing for Any Low-Rank Language Model.",
+    "venue": "stoc 2025",
+    "citation": "Liu, Allen, and Ankur Moitra. “Model Stealing for Any Low-Rank Language Model.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1755–61. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718220."
+  },
+  {
+    "doi": "10.1145/3717823.3718296",
+    "title": "QMA vs QCMA and Pseudorandomness.",
+    "venue": "stoc 2025",
+    "citation": "Liu, Jiahui, et al. “QMA vs QCMA and Pseudorandomness.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1520–31. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718296."
+  },
+  {
+    "doi": "10.1145/3717823.3718109",
+    "title": "Disjoint Paths Problem with Group-Expressable Constraints.",
+    "venue": "stoc 2025",
+    "citation": "Liu, Chun-Hung, and Youngho Yoo. “Disjoint Paths Problem with Group-Expressable Constraints.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1933–43. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718109."
+  },
+  {
+    "doi": "10.1145/3717823.3718251",
+    "title": "Efficiently Finding and Counting Patterns with Distance Constraints in Sparse Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Lokshtanov, Daniel, et al. “Efficiently Finding and Counting Patterns with Distance Constraints in Sparse Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1965–74. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718251."
+  },
+  {
+    "doi": "10.1145/3717823.3718192",
+    "title": "Subexponential Parameterized Algorithms for Hitting Subgraphs.",
+    "venue": "stoc 2025",
+    "citation": "Lokshtanov, Daniel, et al. “Subexponential Parameterized Algorithms for Hitting Subgraphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1975–84. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718192."
+  },
+  {
+    "doi": "10.1145/3717823.3718295",
+    "title": "Fingerprinting Codes Meet Geometry: Improved Lower Bounds for Private Query Release and Adaptive Data Analysis.",
+    "venue": "stoc 2025",
+    "citation": "Lyu, Xin, and Kunal Talwar. “Fingerprinting Codes Meet Geometry: Improved Lower Bounds for Private Query Release and Adaptive Data Analysis.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2374–85. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718295."
+  },
+  {
+    "doi": "10.1145/3717823.3718254",
+    "title": "How to Construct Random Unitaries.",
+    "venue": "stoc 2025",
+    "citation": "Ma, Fermi, and Hsin-Yuan Huang. “How to Construct Random Unitaries.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 806–09. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718254."
+  },
+  {
+    "doi": "10.1145/3717823.3718148",
+    "title": "Refuting the Direct Sum Conjecture for Total Functions in Deterministic Communication Complexity.",
+    "venue": "stoc 2025",
+    "citation": "Mackenzie, Simon, and Abdallah Saffidine. “Refuting the Direct Sum Conjecture for Total Functions in Deterministic Communication Complexity.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 572–83. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718148."
+  },
+  {
+    "doi": "10.1145/3717823.3718266",
+    "title": "Permutation Superposition Oracles for Quantum Query Lower Bounds.",
+    "venue": "stoc 2025",
+    "citation": "Majenz, Christian, et al. “Permutation Superposition Oracles for Quantum Query Lower Bounds.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1508–19. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718266."
+  },
+  {
+    "doi": "10.1145/3717823.3718228",
+    "title": "Improved Bounds for Testing Low Stabilizer Complexity States.",
+    "venue": "stoc 2025",
+    "citation": "Mehraban, Saeed, and Mehrdad Tahmasbi. “Improved Bounds for Testing Low Stabilizer Complexity States.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1222–33. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718228."
+  },
+  {
+    "doi": "10.1145/3717823.3718135",
+    "title": "The FPᴺᴾ versus #P Dichotomy for #EO.",
+    "venue": "stoc 2025",
+    "citation": "Meng, Boning, et al. “The FPᴺᴾ versus #P Dichotomy for #EO.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1795–806. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718135."
+  },
+  {
+    "doi": "10.1145/3717823.3718133",
+    "title": "Cryptographic Characterization of Quantum Advantage.",
+    "venue": "stoc 2025",
+    "citation": "Morimae, Tomoyuki, et al. “Cryptographic Characterization of Quantum Advantage.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1863–74. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718133."
+  },
+  {
+    "doi": "10.1145/3717823.3718292",
+    "title": "Weak Recovery, Hypothesis Testing, and Mutual Information in Stochastic Block Models and Planted Factor Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Mossel, Elchanan, et al. “Weak Recovery, Hypothesis Testing, and Mutual Information in Stochastic Block Models and Planted Factor Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2062–73. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718292."
+  },
+  {
+    "doi": "10.1145/3717823.3718186",
+    "title": "Good Binary Quantum Codes with Transversal CCZ Gate.",
+    "venue": "stoc 2025",
+    "citation": "Nguyen, Quynh T. “Good Binary Quantum Codes with Transversal CCZ Gate.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 697–706. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718186."
+  },
+  {
+    "doi": "10.1145/3717823.3718318",
+    "title": "Quantum Fault Tolerance with Constant-Space and Logarithmic-Time Overheads.",
+    "venue": "stoc 2025",
+    "citation": "Nguyen, Quynh T., and Christopher A. Pattison. “Quantum Fault Tolerance with Constant-Space and Logarithmic-Time Overheads.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 730–37. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718318."
+  },
+  {
+    "doi": "10.1145/3717823.3718116",
+    "title": "Faster Weighted and Unweighted Tree Edit Distance and APSP Equivalence.",
+    "venue": "stoc 2025",
+    "citation": "Nogler, Jakob, et al. “Faster Weighted and Unweighted Tree Edit Distance and APSP Equivalence.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2167–78. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718116."
+  },
+  {
+    "doi": "10.1145/3717823.3718269",
+    "title": "Vanishing of Schubert Coefficients.",
+    "venue": "stoc 2025",
+    "citation": "Pak, Igor, and Colleen Robichaux. “Vanishing of Schubert Coefficients.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1118–29. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718269."
+  },
+  {
+    "doi": "10.1145/3717823.3718206",
+    "title": "List-Decoding Capacity Implies Capacity on the q-ary Symmetric Channel.",
+    "venue": "stoc 2025",
+    "citation": "Pernice, Francisco, et al. “List-Decoding Capacity Implies Capacity on the 𝑞-Ary Symmetric Channel.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 855–66. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718206."
+  },
+  {
+    "doi": "10.1145/3717823.3718256",
+    "title": "A Sharp Version of Talagrand&apos;s Selector Process Conjecture and an Application to Rounding Fractional Covers.",
+    "venue": "stoc 2025",
+    "citation": "Pham, Huy Tuan. “A Sharp Version of Talagrand’s Selector Process Conjecture and an Application to Rounding Fractional Covers.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 322–28. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718256."
+  },
+  {
+    "doi": "10.1145/3717823.3718134",
+    "title": "Testing Support Size More Efficiently Than Learning Histograms.",
+    "venue": "stoc 2025",
+    "citation": "Ferreira Pinto Jr., Renato, and Nathaniel Harms. “Testing Support Size More Efficiently Than Learning Histograms.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 995–1006. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718134."
+  },
+  {
+    "doi": "10.1145/3717823.3718151",
+    "title": "Sum-of-Squares Lower Bounds for Coloring Random Graphs.",
+    "venue": "stoc 2025",
+    "citation": "Potechin, Aaron, and Jeff Xu. “Sum-of-Squares Lower Bounds for Coloring Random Graphs.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 84–95. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718151."
+  },
+  {
+    "doi": "10.1145/3717823.3718271",
+    "title": "Truly Supercritical Trade-Offs for Resolution, Cutting Planes, Monotone Circuits, and Weisfeiler-Leman.",
+    "venue": "stoc 2025",
+    "citation": "de Rezende, Susanna F., et al. “Truly Supercritical Trade-Offs for Resolution, Cutting Planes, Monotone Circuits, and Weisfeiler–Leman.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1371–82. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718271."
+  },
+  {
+    "doi": "10.1145/3717823.3718315",
+    "title": "A Generalized Trace Reconstruction Problem: Recovering a String of Probabilities.",
+    "venue": "stoc 2025",
+    "citation": "Rivkin, Joey, et al. “A Generalized Trace Reconstruction Problem: Recovering a String of Probabilities.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1657–67. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718315."
+  },
+  {
+    "doi": "10.1145/3717823.3718268",
+    "title": "Efficient Thermalization and Universal Quantum Computing with Quantum Gibbs Samplers.",
+    "venue": "stoc 2025",
+    "citation": "Rouzé, Cambyse, et al. “Efficient Thermalization and Universal Quantum Computing with Quantum Gibbs Samplers.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1488–95. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718268."
+  },
+  {
+    "doi": "10.1145/3717823.3718258",
+    "title": "Strong XOR Lemma for Information Complexity.",
+    "venue": "stoc 2025",
+    "citation": "Sawettamalya, Pachara, and Huacheng Yu. “Strong XOR Lemma for Information Complexity.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1626–37. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718258."
+  },
+  {
+    "doi": "10.1145/3717823.3718290",
+    "title": "A Tolerant Independent Set Tester.",
+    "venue": "stoc 2025",
+    "citation": "Seth, Cameron. “A Tolerant Independent Set Tester.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1031–42. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718290."
+  },
+  {
+    "doi": "10.1145/3717823.3718219",
+    "title": "Better Approximation for Weighted k-Matroid Intersection.",
+    "venue": "stoc 2025",
+    "citation": "Singer, Neta, and Theophile Thiery. “Better Approximation for Weighted 𝑘-Matroid Intersection.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1142–53. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718219."
+  },
+  {
+    "doi": "10.1145/3717823.3718253",
+    "title": "Dimension Independent and Computationally Efficient Shadow Tomography.",
+    "venue": "stoc 2025",
+    "citation": "Sinha, Pulkit. “Dimension Independent and Computationally Efficient Shadow Tomography.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1242–53. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718253."
+  },
+  {
+    "doi": "10.1145/3717823.3718294",
+    "title": "Sharp Phase Transitions in Estimation with Low-Degree Polynomials.",
+    "venue": "stoc 2025",
+    "citation": "Sohn, Youngtak, and Alexander S. Wein. “Sharp Phase Transitions in Estimation with Low-Degree Polynomials.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 891–902. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718294."
+  },
+  {
+    "doi": "10.1145/3717823.3718242",
+    "title": "Faster Rates for No-Regret Learning in General Games via Cautious Optimism.",
+    "venue": "stoc 2025",
+    "citation": "Soleymani, Ashkan, et al. “Faster Rates for No-Regret Learning in General Games via Cautious Optimism.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 518–29. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718242."
+  },
+  {
+    "doi": "10.1145/3717823.3718263",
+    "title": "Symmetric Perceptrons, Number Partitioning and Lattices.",
+    "venue": "stoc 2025",
+    "citation": "Vafa, Neekon, and Vinod Vaikuntanathan. “Symmetric Perceptrons, Number Partitioning and Lattices.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2191–202. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718263."
+  },
+  {
+    "doi": "10.1145/3717823.3718255",
+    "title": "Breaking the Barrier of Self-Concordant Barriers: Faster Interior Point Methods for M-Matrices.",
+    "venue": "stoc 2025",
+    "citation": "Vladu, Adrian. “Breaking the Barrier of Self-Concordant Barriers: Faster Interior Point Methods for M-Matrices.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 2213–24. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718255."
+  },
+  {
+    "doi": "10.1145/3717823.3718321",
+    "title": "Harmonic Decomposition in Data Sketches.",
+    "venue": "stoc 2025",
+    "citation": "Wang, Dingyu. “Harmonic Decomposition in Data Sketches.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 383–94. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718321."
+  },
+  {
+    "doi": "10.1145/3717823.3718225",
+    "title": "Simulating Time with Square-Root Space.",
+    "venue": "stoc 2025",
+    "citation": "Williams, R. Ryan. “Simulating Time with Square-Root Space.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 13–23. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718225."
+  },
+  {
+    "doi": "10.1145/3717823.3718115",
+    "title": "Learning the Structure of Any Hamiltonian from Minimal Assumptions.",
+    "venue": "stoc 2025",
+    "citation": "Zhao, Andrew. “Learning the Structure of Any Hamiltonian from Minimal Assumptions.” Proceedings of the 57th Annual ACM Symposium on Theory of Computing, ACM, 15 June 2025, pp. 1201–11. STOC ’25: 57th Annual ACM Symposium on Theory of Computing, Crossref, https://doi.org/10.1145/3717823.3718115."
   }
 ]

--- a/data/sources.csv
+++ b/data/sources.csv
@@ -13,3 +13,6 @@ podc,2025
 wdag,2024
 sirocco,2025
 isaac,2024
+soda,2025
+stacs,2025
+stoc,2025


### PR DESCRIPTION
I put back ISAAC conference and added SODA STACS, and STOC, which are interesting conferences (in my opinion), with diverse topics that may be interesting for the reading group. 

On a side note, I tried to remake the issue I had with wdag-DISC. I just realized I had the wrong year, and 2025 wasn't published yet (it's in October).  You already fixed this so there is no extra need on this.